### PR TITLE
Feat/member delete api

### DIFF
--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -16,30 +16,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+        with:
+          fetch-depth: 2
 
       - name: Install Docker
         # uses: docker-practice/actions-setup-docker@master
         # docker-practice/actions-setup-docker@master waiting for PR
         # REF: https://github.com/docker-practice/actions-setup-docker/pull/33
         uses: DimosthenisK/actions-setup-docker@fc48ecc37a6c3fe57342c08b4bc548926a27aa4a
-      
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      
+
       - name: Install Yarn
         run: npm install -g yarn
-      
+
       - name: Set resolutions to correct typescript version
         uses: jossef/action-set-json-field@v2
         with:
           file: package.json
           field: resolutions
-          value: "{ \"typescript\": \"${{ matrix.typescript-version }}\"}"
+          value: '{ "typescript": "${{ matrix.typescript-version }}"}'
           parse_json: true
-      
+
       - name: Install
         # bcrypt depends on post-scripts since --ignore-scripts flag will disable it.
         run: |

--- a/src/entity/MemberNote.ts
+++ b/src/entity/MemberNote.ts
@@ -14,6 +14,9 @@ export class MemberNote {
   @PrimaryGeneratedColumn()
   id: string;
 
+  @Column('text', { name: 'member_id', unique: true })
+  memberId: string;
+
   @Column('text', { name: 'author_id' })
   authorId: string;
 

--- a/src/entity/MemberPermissionExtra.ts
+++ b/src/entity/MemberPermissionExtra.ts
@@ -9,6 +9,9 @@ export class MemberPermissionExtra {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Column('text', { name: 'member_id', unique: true })
+  memberId: string;
+
   @Column('timestamp with time zone', {
     name: 'created_at',
     default: () => 'now()',

--- a/src/entity/MemberTask.ts
+++ b/src/entity/MemberTask.ts
@@ -11,6 +11,9 @@ export class MemberTask {
   @Column('text', { name: 'title' })
   title: string;
 
+  @Column('text', { name: 'member_id', unique: true })
+  memberId: string;
+
   @Column('text', { name: 'priority', default: () => "'high'" })
   priority: string;
 

--- a/src/entity/MemberTrackingLog.ts
+++ b/src/entity/MemberTrackingLog.ts
@@ -7,6 +7,9 @@ export class MemberTrackingLog {
   @PrimaryGeneratedColumn()
   id: string;
 
+  @Column('text', { name: 'member_id', unique: true })
+  memberId: string;
+
   @Column('text', { name: 'source', nullable: true })
   source: string | null;
 

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -8,6 +8,8 @@ import {
   UnauthorizedException,
   BadRequestException,
   UseGuards,
+  Delete,
+  Param,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { ConfigService } from '@nestjs/config';
@@ -18,8 +20,15 @@ import { ImportJob, ImporterTasker } from '~/tasker/importer.tasker';
 import { ExporterTasker, MemberExportJob } from '~/tasker/exporter.tasker';
 import { Local } from '~/decorator';
 
-import { MemberExportDTO, MemberGetDTO, MemberGetResultDTO, MemberImportDTO } from './member.dto';
+import {
+  MemberDeleteResultDTO,
+  MemberExportDTO,
+  MemberGetDTO,
+  MemberGetResultDTO,
+  MemberImportDTO,
+} from './member.dto';
 import { MemberService } from './member.service';
+import { APIException } from '~/api.excetion';
 
 @UseGuards(AuthGuard)
 @Controller({
@@ -164,5 +173,25 @@ export class MemberController {
       exportMime,
     };
     await this.exportQueue.add(exportJob);
+  }
+
+  @Delete('email/:email')
+  public async deleteMember(
+    @Local('member') member: JwtMember,
+    @Param('email') email: string,
+  ): Promise<MemberDeleteResultDTO> {
+    const { appId, role } = member;
+    if (role !== 'app-owner') {
+      throw new UnauthorizedException(
+        { message: 'no permission to delete member' },
+        'User permission is not met required permissions.',
+      );
+    }
+    try {
+      const deleteResult = await this.memberService.deleteMemberByEmail(appId, email);
+      return { code: 'SUCCESS', message: deleteResult };
+    } catch (error) {
+      throw new APIException({ code: 'ERROR', message: error.message });
+    }
   }
 }

--- a/src/member/member.dto.ts
+++ b/src/member/member.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsEmail, IsEnum, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { DeleteResult } from 'typeorm';
 import { Cursor } from 'typeorm-cursor-pagination';
 
 import { MemberRole } from './member.type';
@@ -130,6 +131,11 @@ export class MemberImportResultDTO {
   insertedCount: number;
   failedCount: number;
   failedErrors: any;
+}
+
+export class MemberDeleteResultDTO {
+  code: 'SUCCESS' | 'ERROR';
+  message: DeleteResult;
 }
 
 export class MemberGeneralLoginDTO {

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -23,9 +23,11 @@ import { PaymentLog } from '~/payment/payment_log.entity';
 import { MemberTrackingLog } from '~/entity/MemberTrackingLog';
 import { MemberPermissionExtra } from '~/entity/MemberPermissionExtra';
 import { Invoice } from '~/invoice/invoice.entity';
-import { MemberOauth } from '~/entity/MemberOauth';
 import { MemberNote } from '~/entity/MemberNote';
 import { MemberTask } from '~/entity/MemberTask';
+import { Coupon } from '~/coupon/entity/coupon.entity';
+import { ProgramContentProgress } from '~/entity/ProgramContentProgress';
+import { ProgramContentLog } from '~/entity/ProgramContentLog';
 
 @Injectable()
 export class MemberInfrastructure {
@@ -355,7 +357,12 @@ export class MemberInfrastructure {
       const memberTrackingLogRepo = manager.getRepository(MemberTrackingLog);
       const memberNoteRepo = manager.getRepository(MemberNote);
       const memberTaskRepo = manager.getRepository(MemberTask);
+
+      const programContentProgressRepo = manager.getRepository(ProgramContentProgress);
+      const programContentLogRepo = manager.getRepository(ProgramContentLog);
+
       const notificationRepo = manager.getRepository(Notification);
+      const couponRepo = manager.getRepository(Coupon);
       const paymentLogRepo = manager.getRepository(PaymentLog);
       const invoiceRepo = manager.getRepository(Invoice);
       const orderProductRepo = manager.getRepository(OrderProduct);
@@ -407,6 +414,9 @@ export class MemberInfrastructure {
       );
       await orderLogRepo.remove(orderLogs);
 
+      await programContentLogRepo.delete({ memberId: member.id });
+      await programContentProgressRepo.delete({ memberId: member.id });
+      await couponRepo.delete({ memberId: member.id });
       await memberTagRepo.delete({ memberId: member.id });
       await memberOauthRepo.delete({ memberId: member.id });
       await memberCategoryRepo.delete({ memberId: member.id });

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -24,6 +24,8 @@ import { MemberTrackingLog } from '~/entity/MemberTrackingLog';
 import { MemberPermissionExtra } from '~/entity/MemberPermissionExtra';
 import { Invoice } from '~/invoice/invoice.entity';
 import { MemberOauth } from '~/entity/MemberOauth';
+import { MemberNote } from '~/entity/MemberNote';
+import { MemberTask } from '~/entity/MemberTask';
 
 @Injectable()
 export class MemberInfrastructure {
@@ -351,6 +353,8 @@ export class MemberInfrastructure {
       const memberPropertyRepo = manager.getRepository(MemberProperty);
       const memberPermissionExtraRepo = manager.getRepository(MemberPermissionExtra);
       const memberTrackingLogRepo = manager.getRepository(MemberTrackingLog);
+      const memberNoteRepo = manager.getRepository(MemberNote);
+      const memberTaskRepo = manager.getRepository(MemberTask);
       const notificationRepo = manager.getRepository(Notification);
       const paymentLogRepo = manager.getRepository(PaymentLog);
       const invoiceRepo = manager.getRepository(Invoice);
@@ -408,6 +412,8 @@ export class MemberInfrastructure {
       await memberCategoryRepo.delete({ memberId: member.id });
       await memberDeviceRepo.delete({ memberId: member.id });
       await memberTrackingLogRepo.delete({ memberId: member.id });
+      await memberNoteRepo.delete({ memberId: member.id });
+      await memberTaskRepo.delete({ memberId: member.id });
       await memberPhoneRepo.delete({ memberId: member.id });
       await memberPropertyRepo.delete({ memberId: member.id });
       await memberPermissionExtraRepo.delete({ memberId: member.id });

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -23,6 +23,7 @@ import { PaymentLog } from '~/payment/payment_log.entity';
 import { MemberTrackingLog } from '~/entity/MemberTrackingLog';
 import { MemberPermissionExtra } from '~/entity/MemberPermissionExtra';
 import { Invoice } from '~/invoice/invoice.entity';
+import { MemberOauth } from '~/entity/MemberOauth';
 
 @Injectable()
 export class MemberInfrastructure {
@@ -344,6 +345,7 @@ export class MemberInfrastructure {
       const memberRepo = manager.getRepository(Member);
       const memberCategoryRepo = manager.getRepository(MemberCategory);
       const memberTagRepo = manager.getRepository(MemberTag);
+      const memberOauthRepo = manager.getRepository(MemberOauth);
       const memberDeviceRepo = manager.getRepository(MemberDevice);
       const memberPhoneRepo = manager.getRepository(MemberPhone);
       const memberPropertyRepo = manager.getRepository(MemberProperty);
@@ -402,6 +404,7 @@ export class MemberInfrastructure {
       await orderLogRepo.remove(orderLogs);
 
       await memberTagRepo.delete({ memberId: member.id });
+      await memberOauthRepo.delete({ memberId: member.id });
       await memberCategoryRepo.delete({ memberId: member.id });
       await memberDeviceRepo.delete({ memberId: member.id });
       await memberTrackingLogRepo.delete({ memberId: member.id });

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
 import { chunk, flatten, isNull } from 'lodash';
-import { EntityManager, Equal, FindOptionsWhere, ILike, In } from 'typeorm';
+import { EntityManager, Equal, FindOptionsWhere, ILike, In, DeleteResult } from 'typeorm';
 import { ValidationError, isDateString, isEmpty } from 'class-validator';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
@@ -15,6 +15,7 @@ import { MemberCsvHeaderMapping } from './class/csvHeaderMapping';
 import { CsvRawMember } from './class/csvRawMember';
 import { MemberInfrastructure } from './member.infra';
 import {
+  MemberDeleteResultDTO,
   MemberGetConditionDTO,
   MemberGetQueryOptionsDTO,
   MemberGetResultDTO,
@@ -25,6 +26,7 @@ import { MemberCategory } from './entity/member_category.entity';
 import { MemberProperty } from './entity/member_property.entity';
 import { MemberPhone } from './entity/member_phone.entity';
 import { MemberTag } from './entity/member_tag.entity';
+import { APIException } from '~/api.excetion';
 
 @Injectable()
 export class MemberService {
@@ -334,5 +336,9 @@ export class MemberService {
         return csvRawMember;
       })
       .map((each) => each.serializeToCsvRawRow(headerInfos));
+  }
+
+  async deleteMemberByEmail(appId: string, email: string): Promise<DeleteResult> {
+    return this.memberInfra.deleteMemberByEmail(appId, email, this.entityManager);
   }
 }

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,6 +1,5 @@
 import { Body, Controller, Get, Param, Post, Put, UseGuards, Request } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
-import { Request as ExRequest } from 'express';
 import { AuthGuard } from '~/auth/auth.guard';
 import { AuthService } from '~/auth/auth.service';
 import { APIException } from '~/api.excetion';

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -1627,6 +1627,7 @@ describe('MemberController (e2e)', () => {
       await request(application.getHttpServer())
         .delete(`${route}/no@mail.com`)
         .set('Authorization', 'Bearer something')
+        .set('host', appHost.host)
         .expect(401);
     });
 
@@ -1645,6 +1646,7 @@ describe('MemberController (e2e)', () => {
       const res = await request(application.getHttpServer())
         .delete(`${route}/no@mail.com`)
         .set('Authorization', `Bearer ${token}`)
+        .set('host', appHost.host)
         .expect(401);
 
       expect(res.body).toHaveProperty('message');
@@ -1666,13 +1668,14 @@ describe('MemberController (e2e)', () => {
       const res = await request(application.getHttpServer())
         .delete(`${route}/no@mail.com`)
         .set('Authorization', `Bearer ${token}`)
+        .set('host', appHost.host)
         .expect(400);
 
       expect(res.body).toHaveProperty('code', 'ERROR');
       expect(res.body).toHaveProperty('message');
     });
 
-    it.only('Should delete member successfully', async () => {
+    it('Should delete member successfully', async () => {
       const memberId = v4();
       const insertedMember = new Member();
       insertedMember.appId = app.id;

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -1624,9 +1624,11 @@ describe('MemberController (e2e)', () => {
     const route = '/members/email';
 
     it('Should raise unauthorized exception', async () => {
+      const testAuthToken = 'TestTokenWithNoRealCredentials';
+
       await request(application.getHttpServer())
         .delete(`${route}/no@mail.com`)
-        .set('Authorization', 'Bearer something')
+        .set('Authorization', `Bearer ${testAuthToken}`)
         .set('host', appHost.host)
         .expect(401);
     });

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -1693,7 +1693,7 @@ describe('MemberController (e2e)', () => {
 
       const insertedMemberTag = new MemberTag();
       insertedMemberTag.id = v4();
-      insertedMemberTag.memberId = memberId;
+      insertedMemberTag.member = insertedMember;
       insertedMemberTag.tagName = insertedTag.name;
       await manager.save(insertedMemberTag);
 
@@ -1706,7 +1706,7 @@ describe('MemberController (e2e)', () => {
 
       const insertedMemberCategory = new MemberCategory();
       insertedMemberCategory.id = v4();
-      insertedMemberCategory.memberId = memberId;
+      insertedMemberCategory.member = insertedMember;
       insertedMemberCategory.categoryId = categoryId;
       insertedMemberCategory.position = 0;
       await manager.save(insertedMemberCategory);
@@ -1714,26 +1714,26 @@ describe('MemberController (e2e)', () => {
       const { id: propertyId } = await manager.save(memberProperty);
       const insertedMemberProperty = new MemberProperty();
       insertedMemberProperty.id = v4();
-      insertedMemberProperty.memberId = memberId;
+      insertedMemberProperty.member = insertedMember;
       insertedMemberProperty.propertyId = propertyId;
       insertedMemberProperty.value = `test member property value`;
       await manager.save(insertedMemberProperty);
 
       const insertedMemberPhone = new MemberPhone();
       insertedMemberPhone.id = v4();
-      insertedMemberPhone.memberId = memberId;
+      insertedMemberPhone.member = insertedMember;
       insertedMemberPhone.phone = `09000000000`;
       await manager.save(insertedMemberPhone);
 
       const insertedMemberDevice = new MemberDevice();
       insertedMemberDevice.id = v4();
-      insertedMemberDevice.memberId = memberId;
+      insertedMemberDevice.member = insertedMember;
       insertedMemberDevice.fingerprintId = 'test';
       await manager.save(insertedMemberDevice);
 
       const insertedMemberOauth = new MemberOauth();
       insertedMemberOauth.id = v4();
-      insertedMemberOauth.memberId = memberId;
+      insertedMemberOauth.member = insertedMember;
       insertedMemberOauth.provider = 'cw';
       insertedMemberOauth.providerUserId = 'some_provider_id';
       await manager.save(insertedMemberOauth);
@@ -1746,19 +1746,19 @@ describe('MemberController (e2e)', () => {
 
       const insertedMemberPermissionExtra = new MemberPermissionExtra();
       insertedMemberPermissionExtra.id = v4();
-      insertedMemberPermissionExtra.memberId = memberId;
+      insertedMemberPermissionExtra.member = insertedMember;
       insertedMemberPermissionExtra.permission = insertedPermission;
       await manager.save(insertedMemberPermissionExtra);
 
       const insertedMemberNote = new MemberNote();
-      insertedMemberNote.memberId = memberId;
+      insertedMemberNote.member = insertedMember;
       insertedMemberNote.authorId = memberId;
       insertedMemberNote.type = 'outbound';
       insertedMemberNote.status = 'missed';
       await manager.save(insertedMemberNote);
 
       const insertedMemberTask = new MemberTask();
-      insertedMemberTask.memberId = memberId;
+      insertedMemberTask.member = insertedMember;
       insertedMemberTask.title = 'title';
       insertedMemberTask.priority = 'high';
       insertedMemberTask.status = 'done';
@@ -1797,7 +1797,7 @@ describe('MemberController (e2e)', () => {
       const insertedProgramContentProgress = new ProgramContentProgress();
       insertedProgramContentProgress.programContent = insertedProgramContent;
       insertedProgramContentProgress.id = v4();
-      insertedProgramContentProgress.memberId = memberId;
+      insertedProgramContentProgress.member = insertedMember;
       await manager.save(insertedProgramContentProgress);
 
       const insertedNotification = new Notification();
@@ -1822,7 +1822,7 @@ describe('MemberController (e2e)', () => {
 
       const insertedCoupon = new Coupon();
       insertedCoupon.id = v4();
-      insertedCoupon.memberId = memberId;
+      insertedCoupon.member = insertedMember;
       insertedCoupon.couponCode = insertCouponCode;
       await manager.save(insertedCoupon);
 

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -1786,7 +1786,7 @@ describe('MemberController (e2e)', () => {
 
       const insertedProgramContent = new ProgramContent();
       insertedProgramContent.id = v4();
-      insertedProgramContent.title = '4-8用蒙氏概念解決8大教養難題-8';
+      insertedProgramContent.title = 'default';
       insertedProgramContent.position = 1;
       insertedProgramContent.contentSectionId = v4();
       insertedProgramContent.displayMode = 'payToWatch';
@@ -1826,9 +1826,22 @@ describe('MemberController (e2e)', () => {
       insertedCoupon.couponCode = insertCouponCode;
       await manager.save(insertedCoupon);
 
+      const insertedParentOrderLog = new OrderLog();
+      insertedParentOrderLog.id = v4();
+      insertedParentOrderLog.appId = app.id;
+      insertedParentOrderLog.member = insertedMember;
+      insertedParentOrderLog.invoiceOptions = {
+        name: 'cc',
+        email: 'cc@qraft.app',
+        phone: '1111111111',
+      };
+      insertedParentOrderLog.status = 'SUCCESS';
+      await manager.save(insertedParentOrderLog);
+
       const insertedOrderLog = new OrderLog();
       insertedOrderLog.appId = app.id;
       insertedOrderLog.member = insertedMember;
+      insertedOrderLog.parentOrder = insertedParentOrderLog;
       insertedOrderLog.invoiceOptions = {
         name: 'cc',
         email: 'cc@qraft.app',
@@ -1868,6 +1881,19 @@ describe('MemberController (e2e)', () => {
       insertedOrderProduct.price = 1000;
       insertedOrderProduct.currency = insertedCurrency;
       await manager.save(insertedOrderProduct);
+
+      const insertedInvoice = new Invoice();
+      insertedInvoice.order = insertedOrderLog;
+      insertedInvoice.price = 1000;
+      insertedInvoice.no = 'AA00000001';
+      await manager.save(insertedInvoice);
+
+      const insertedPaymentLog = new PaymentLog();
+      insertedPaymentLog.order = insertedOrderLog;
+      insertedPaymentLog.no = '1555336487636';
+      insertedPaymentLog.status = 'SUCCESS';
+      insertedPaymentLog.price = 1000;
+      await manager.save(insertedPaymentLog);
 
       // TODO: add more relations
 

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -49,6 +49,10 @@ import { ProgramContent } from '~/program/entity/program_content.entity';
 import { ProgramContentBody } from '~/entity/ProgramContentBody';
 import { ProgramContentSection } from '~/entity/ProgramContentSection';
 import { Program } from '~/entity/Program';
+import { CouponCode } from '~/entity/CouponCode';
+import { CouponPlan } from '~/entity/CouponPlan';
+import { Product } from '~/entity/Product';
+import { Currency } from '~/entity/Currency';
 
 describe('MemberController (e2e)', () => {
   let application: INestApplication;
@@ -86,6 +90,10 @@ describe('MemberController (e2e)', () => {
   let programContentBodyRepo: Repository<ProgramContentBody>;
   let programRepo: Repository<Program>;
   let programContentSectionRepo: Repository<ProgramContentSection>;
+  let couponCodeRepo: Repository<CouponCode>;
+  let couponPlanRepo: Repository<CouponPlan>;
+  let productRepo: Repository<Product>;
+  let currencyRepo: Repository<Currency>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -129,6 +137,10 @@ describe('MemberController (e2e)', () => {
     programContentBodyRepo = manager.getRepository(ProgramContentBody);
     programRepo = manager.getRepository(Program);
     programContentSectionRepo = manager.getRepository(ProgramContentSection);
+    couponCodeRepo = manager.getRepository(CouponCode);
+    couponPlanRepo = manager.getRepository(CouponPlan);
+    productRepo = manager.getRepository(Product);
+    currencyRepo = manager.getRepository(Currency);
 
     await programContentLogRepo.delete({});
     await programContentProgressRepo.delete({});
@@ -138,11 +150,15 @@ describe('MemberController (e2e)', () => {
     await programRepo.delete({});
     await paymentLogRepo.delete({});
     await couponRepo.delete({});
+    await couponCodeRepo.delete({});
+    await couponPlanRepo.delete({});
     await notificationRepo.delete({});
     await invoiceRepo.delete({});
     await orderProductRepo.delete({});
+    await productRepo.delete({});
     await orderDiscountRepo.delete({});
     await orderLogRepo.delete({});
+    await currencyRepo.delete({});
     await memberTaskRepo.delete({});
     await memberNoteRepo.delete({});
     await memberPermissionExtraRepo.delete({});
@@ -179,11 +195,15 @@ describe('MemberController (e2e)', () => {
     await programRepo.delete({});
     await paymentLogRepo.delete({});
     await couponRepo.delete({});
+    await couponCodeRepo.delete({});
+    await couponPlanRepo.delete({});
     await notificationRepo.delete({});
     await invoiceRepo.delete({});
     await orderProductRepo.delete({});
+    await productRepo.delete({});
     await orderDiscountRepo.delete({});
     await orderLogRepo.delete({});
+    await currencyRepo.delete({});
     await memberTaskRepo.delete({});
     await memberNoteRepo.delete({});
     await memberPermissionExtraRepo.delete({});
@@ -1779,6 +1799,75 @@ describe('MemberController (e2e)', () => {
       insertedProgramContentProgress.id = v4();
       insertedProgramContentProgress.memberId = memberId;
       await manager.save(insertedProgramContentProgress);
+
+      const insertedNotification = new Notification();
+      insertedNotification.id = v4();
+      insertedNotification.description = 'default';
+      insertedNotification.sourceMember = insertedMember;
+      insertedNotification.targetMember = insertedMember;
+      await manager.save(insertedNotification);
+
+      const insertCouponPlan = new CouponPlan();
+      insertCouponPlan.title = 'default';
+      insertCouponPlan.amount = 100;
+      await manager.save(insertCouponPlan);
+
+      const insertCouponCode = new CouponCode();
+      insertCouponCode.appId = app.id;
+      insertCouponCode.code = 'default';
+      insertCouponCode.count = 1;
+      insertCouponCode.couponPlan = insertCouponPlan;
+      insertCouponCode.remaining = 100;
+      await manager.save(insertCouponCode);
+
+      const insertedCoupon = new Coupon();
+      insertedCoupon.id = v4();
+      insertedCoupon.memberId = memberId;
+      insertedCoupon.couponCode = insertCouponCode;
+      await manager.save(insertedCoupon);
+
+      const insertedOrderLog = new OrderLog();
+      insertedOrderLog.appId = app.id;
+      insertedOrderLog.member = insertedMember;
+      insertedOrderLog.invoiceOptions = {
+        name: 'cc',
+        email: 'cc@qraft.app',
+        phone: '1111111111',
+      };
+      insertedOrderLog.status = 'SUCCESS';
+      await manager.save(insertedOrderLog);
+
+      const insertedOrderDiscount = new OrderDiscount();
+      insertedOrderDiscount.id = v4();
+      insertedOrderDiscount.name = 'default';
+      insertedOrderDiscount.target = v4();
+      insertedOrderDiscount.price = 100;
+      insertedOrderDiscount.type = 'Coupon';
+      insertedOrderDiscount.order = insertedOrderLog;
+      await manager.save(insertedOrderDiscount);
+
+      const insertedProduct = new Product();
+      insertedProduct.id = v4();
+      insertedProduct.type = 'ActivityTicket';
+      insertedProduct.target = v4();
+      await manager.save(insertedProduct);
+
+      const insertedCurrency = new Currency();
+      insertedCurrency.id = 'TWD';
+      insertedCurrency.minorUnits = 2;
+      insertedCurrency.label = 'default';
+      insertedCurrency.unit = 'default';
+      insertedCurrency.name = 'default';
+      await manager.save(insertedCurrency);
+
+      const insertedOrderProduct = new OrderProduct();
+      insertedOrderProduct.id = v4();
+      insertedOrderProduct.product = insertedProduct;
+      insertedOrderProduct.order = insertedOrderLog;
+      insertedOrderProduct.name = 'default';
+      insertedOrderProduct.price = 1000;
+      insertedOrderProduct.currency = insertedCurrency;
+      await manager.save(insertedOrderProduct);
 
       // TODO: add more relations
 

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -28,9 +28,27 @@ import { Category } from '~/definition/entity/category.entity';
 import { MemberCategory } from '~/member/entity/member_category.entity';
 import { PermissionGroup } from '~/entity/PermissionGroup';
 import { MemberPermissionGroup } from '~/member/entity/member_permission_group.entity';
-import { MemberDevice } from '~/entity/MemberDevice';
+import { MemberDevice } from '~/member/entity/member_device.entity';
 
 import { app, appHost, appPlan, memberProperty } from '../data';
+import { MemberOauth } from '~/member/entity/member_oauth.entity';
+import { MemberPermissionExtra } from '~/entity/MemberPermissionExtra';
+import { Permission } from '~/permission/entity/permission.entity';
+import { MemberNote } from '~/entity/MemberNote';
+import { MemberTask } from '~/entity/MemberTask';
+import { ProgramContentProgress } from '~/entity/ProgramContentProgress';
+import { ProgramContentLog } from '~/entity/ProgramContentLog';
+import { Coupon } from '~/coupon/entity/coupon.entity';
+import { PaymentLog } from '~/payment/payment_log.entity';
+import { Invoice } from '~/invoice/invoice.entity';
+import { OrderDiscount } from '~/order/entity/order_discount.entity';
+import { OrderLog } from '~/order/entity/order_log.entity';
+import { OrderProduct } from '~/order/entity/order_product.entity';
+import { Notification } from '~/entity/Notification';
+import { ProgramContent } from '~/program/entity/program_content.entity';
+import { ProgramContentBody } from '~/entity/ProgramContentBody';
+import { ProgramContentSection } from '~/entity/ProgramContentSection';
+import { Program } from '~/entity/Program';
 
 describe('MemberController (e2e)', () => {
   let application: INestApplication;
@@ -50,6 +68,24 @@ describe('MemberController (e2e)', () => {
   let memberPhoneRepo: Repository<MemberPhone>;
   let memberDeviceRepo: Repository<MemberDevice>;
   let memberPermissionGroupRepo: Repository<MemberPermissionGroup>;
+  let memberOauthRepo: Repository<MemberOauth>;
+  let permissionRepo: Repository<Permission>;
+  let memberPermissionExtraRepo: Repository<MemberPermissionExtra>;
+  let memberNoteRepo: Repository<MemberNote>;
+  let memberTaskRepo: Repository<MemberTask>;
+  let programContentProgressRepo: Repository<ProgramContentProgress>;
+  let programContentLogRepo: Repository<ProgramContentLog>;
+  let notificationRepo: Repository<Notification>;
+  let couponRepo: Repository<Coupon>;
+  let paymentLogRepo: Repository<PaymentLog>;
+  let invoiceRepo: Repository<Invoice>;
+  let orderProductRepo: Repository<OrderProduct>;
+  let orderDiscountRepo: Repository<OrderDiscount>;
+  let orderLogRepo: Repository<OrderLog>;
+  let programContentRepo: Repository<ProgramContent>;
+  let programContentBodyRepo: Repository<ProgramContentBody>;
+  let programRepo: Repository<Program>;
+  let programContentSectionRepo: Repository<ProgramContentSection>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -75,7 +111,43 @@ describe('MemberController (e2e)', () => {
     memberDeviceRepo = manager.getRepository(MemberDevice);
     memberCategoryRepo = manager.getRepository(MemberCategory);
     memberPermissionGroupRepo = manager.getRepository(MemberPermissionGroup);
+    memberOauthRepo = manager.getRepository(MemberOauth);
+    permissionRepo = manager.getRepository(Permission);
+    memberPermissionExtraRepo = manager.getRepository(MemberPermissionExtra);
+    memberNoteRepo = manager.getRepository(MemberNote);
+    memberTaskRepo = manager.getRepository(MemberTask);
+    orderLogRepo = manager.getRepository(OrderLog);
+    orderProductRepo = manager.getRepository(OrderProduct);
+    orderDiscountRepo = manager.getRepository(OrderDiscount);
+    invoiceRepo = manager.getRepository(Invoice);
+    paymentLogRepo = manager.getRepository(PaymentLog);
+    notificationRepo = manager.getRepository(Notification);
+    couponRepo = manager.getRepository(Coupon);
+    programContentProgressRepo = manager.getRepository(ProgramContentProgress);
+    programContentLogRepo = manager.getRepository(ProgramContentLog);
+    programContentRepo = manager.getRepository(ProgramContent);
+    programContentBodyRepo = manager.getRepository(ProgramContentBody);
+    programRepo = manager.getRepository(Program);
+    programContentSectionRepo = manager.getRepository(ProgramContentSection);
 
+    await programContentLogRepo.delete({});
+    await programContentProgressRepo.delete({});
+    await programContentRepo.delete({});
+    await programContentBodyRepo.delete({});
+    await programContentSectionRepo.delete({});
+    await programRepo.delete({});
+    await paymentLogRepo.delete({});
+    await couponRepo.delete({});
+    await notificationRepo.delete({});
+    await invoiceRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderDiscountRepo.delete({});
+    await orderLogRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberNoteRepo.delete({});
+    await memberPermissionExtraRepo.delete({});
+    await permissionRepo.delete({});
+    await memberOauthRepo.delete({});
     await memberDeviceRepo.delete({});
     await memberPermissionGroupRepo.delete({});
     await memberPhoneRepo.delete({});
@@ -99,6 +171,24 @@ describe('MemberController (e2e)', () => {
   });
 
   afterEach(async () => {
+    await programContentLogRepo.delete({});
+    await programContentProgressRepo.delete({});
+    await programContentRepo.delete({});
+    await programContentBodyRepo.delete({});
+    await programContentSectionRepo.delete({});
+    await programRepo.delete({});
+    await paymentLogRepo.delete({});
+    await couponRepo.delete({});
+    await notificationRepo.delete({});
+    await invoiceRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderDiscountRepo.delete({});
+    await orderLogRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberNoteRepo.delete({});
+    await memberPermissionExtraRepo.delete({});
+    await permissionRepo.delete({});
+    await memberOauthRepo.delete({});
     await memberDeviceRepo.delete({});
     await memberPermissionGroupRepo.delete({});
     await memberPhoneRepo.delete({});
@@ -1621,6 +1711,75 @@ describe('MemberController (e2e)', () => {
       insertedMemberDevice.fingerprintId = 'test';
       await manager.save(insertedMemberDevice);
 
+      const insertedMemberOauth = new MemberOauth();
+      insertedMemberOauth.id = v4();
+      insertedMemberOauth.memberId = memberId;
+      insertedMemberOauth.provider = 'cw';
+      insertedMemberOauth.providerUserId = 'some_provider_id';
+      await manager.save(insertedMemberOauth);
+
+      const insertedPermission = new Permission();
+      insertedPermission.id = 'default';
+      insertedPermission.description = 'default';
+      insertedPermission.group = 'activity';
+      await manager.save(insertedPermission);
+
+      const insertedMemberPermissionExtra = new MemberPermissionExtra();
+      insertedMemberPermissionExtra.id = v4();
+      insertedMemberPermissionExtra.memberId = memberId;
+      insertedMemberPermissionExtra.permission = insertedPermission;
+      await manager.save(insertedMemberPermissionExtra);
+
+      const insertedMemberNote = new MemberNote();
+      insertedMemberNote.memberId = memberId;
+      insertedMemberNote.authorId = memberId;
+      insertedMemberNote.type = 'outbound';
+      insertedMemberNote.status = 'missed';
+      await manager.save(insertedMemberNote);
+
+      const insertedMemberTask = new MemberTask();
+      insertedMemberTask.memberId = memberId;
+      insertedMemberTask.title = 'title';
+      insertedMemberTask.priority = 'high';
+      insertedMemberTask.status = 'done';
+      await manager.save(insertedMemberTask);
+
+      const insertProgramContentBody = new ProgramContentBody();
+      insertProgramContentBody.id = v4();
+      await manager.save(insertProgramContentBody);
+
+      const insertedProgram = new Program();
+      insertedProgram.id = v4();
+      insertedProgram.title = 'AAA';
+      insertedProgram.appId = 'demo';
+      insertedProgram.inAdvance = false;
+      insertedProgram.isDeleted = false;
+      insertedProgram.appId = app.id;
+      await manager.save(insertedProgram);
+
+      const insertProgramContentSection = new ProgramContentSection();
+      insertProgramContentSection.id = v4();
+      insertProgramContentSection.program = insertedProgram;
+      insertProgramContentSection.title = 'QQQ';
+      insertProgramContentSection.position = 1;
+      await manager.save(insertProgramContentSection);
+
+      const insertedProgramContent = new ProgramContent();
+      insertedProgramContent.id = v4();
+      insertedProgramContent.title = '4-8用蒙氏概念解決8大教養難題-8';
+      insertedProgramContent.position = 1;
+      insertedProgramContent.contentSectionId = v4();
+      insertedProgramContent.displayMode = 'payToWatch';
+      insertedProgramContent.contentBody = insertProgramContentBody;
+      insertedProgramContent.contentSection = insertProgramContentSection;
+      await manager.save(insertedProgramContent);
+
+      const insertedProgramContentProgress = new ProgramContentProgress();
+      insertedProgramContentProgress.programContent = insertedProgramContent;
+      insertedProgramContentProgress.id = v4();
+      insertedProgramContentProgress.memberId = memberId;
+      await manager.save(insertedProgramContentProgress);
+
       // TODO: add more relations
 
       const jwtSecret = application
@@ -1638,6 +1797,7 @@ describe('MemberController (e2e)', () => {
       const res = await request(application.getHttpServer())
         .delete(`${route}/delete@example.com`)
         .set('Authorization', `Bearer ${token}`)
+        .set('host', appHost.host)
         .expect(200);
 
       expect(res.body).toHaveProperty('code', 'SUCCESS');

--- a/test/tasker/exporter/exporter_tasker.e2e-spec.ts
+++ b/test/tasker/exporter/exporter_tasker.e2e-spec.ts
@@ -174,6 +174,10 @@ describe('ExporterTasker', () => {
     } as Job<MemberExportJob>);
     const { Sheets, SheetNames } = XLSX.read(savedFile);
     const parsed = XLSX.utils.sheet_to_json(Sheets[SheetNames[0]], { defval: '' });
+
+    console.log('parsed', parsed);
+    console.log('parsed.length', parsed.length);
+
     expect(parsed.length).toBe(2);
     const [_, data] = parsed;
     expect(data['流水號']).toBe(testMember.id);
@@ -246,6 +250,7 @@ describe('ExporterTasker', () => {
     } as Job<OrderLogExportJob>);
     const { Sheets, SheetNames } = XLSX.read(savedFile);
     const parsed = XLSX.utils.sheet_to_json(Sheets[SheetNames[0]], { defval: '' });
+    console.log('parsed ', parsed);
     expect(parsed.length).toBe(2);
 
     const [, data] = parsed;


### PR DESCRIPTION
## Description

This update adds a feature to delete members from our system using their email. Aimed at app owners, it enables the removal of members and their associated data, including notifications, orders, coupons, and tasks

## delete relation list 

1. **Notifications**: Both notifications issued by and targeted at the member.
2. **Orders**: All orders associated with the member, including:
   - Order logs and their child logs.
   - Order products and discounts.
3. **Payments**: Payment logs linked to the member's orders.
4. **Invoices**: Invoices generated for the member's transactions.
5. **Coupons**: Any coupons attributed to the member.
6. **Member-Specific Data**:
   - OAuth data indicating member's third-party integrations.
   - Device information including member-specific devices.
   - Phone records linked to the member.
   - Properties and additional data specific to the member.
7. **Member Activities**: 
   - Member tasks, notes, and tracking logs.
   - Member categories, tags, and extra permissions.
8. **Program Content**: 
   - Logs and progress records related to any program content engaged by the member.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The new deletion functionality has been tested through unit tests covering the following scenarios:

- [X] Test A:  Should raise unauthorized exception.
- [X] Test B: Should raise no permission to delete member exception.
- [X] Test C: Should raise no member to delete exception.
- [X] Test D: Should delete member successfully.

