### PR TITLE
feat: Convert email to lowercase when importing new members

### DIFF
--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -226,7 +226,7 @@ export class MemberService {
         member.id = v4();
         member.name = eachRow.name;
         member.username = eachRow.username || eachRow.id;
-        member.email = eachRow.email;
+        member.email = eachRow.email.toLowerCase();
         member.role = eachRow.role || 'general-member';
         member.star = parseInt(eachRow.star, 10);
         member.createdAt = (isDateString(eachRow.createdAt) && new Date(eachRow.createdAt)) || null;

--- a/test/tasker/importer/test-member-import-data-case-to-lower-case.csv
+++ b/test/tasker/importer/test-member-import-data-case-to-lower-case.csv
@@ -1,0 +1,3 @@
+流水號,姓名,帳號,信箱,星等,身份,承辦人信箱,電話1,電話2,電話3,標籤1,標籤2,標籤3,分類1,分類2,分類3,test-property,建立日期,上次登入日期
+id,name,username,email,star,role,manager.email,phones.1,phones.2,phones.3,tags.1,tags.2,tags.3,categories.1,categories.2,categories.3,properties.1,createdAt,loginedAt
+,AA,tolowercase@example.com,TOLOWERCASE@example.com,999,,,987654321,900000000,,,工程,,測試分類,前端工程,,Somet-test-value,,


### PR DESCRIPTION
## 描述

1. 匯入excel若沒有給予id欄位的皆視為匯入新會員
2. 新會員email一率轉小寫
3. 轉小寫email若已於資料庫重複則匯入失敗

## 作法
`isEmpty(eachRow.id)` 為true時則 `member.email = eachRow.email.toLowerCase();`

## 測試情境
1. 測試檔匯入email為大寫，匯入後新增的會員應為小寫email 
2. 測試檔匯入email為大寫，匯入後判斷小寫後的email會與現有資料庫的email重複，匯入失敗

## 相關議題的repo 分支
**lodestar-app-backend** [feature/lowercase-email-import](https://github.com/urfit-tech/lodestar-app-backend/pull/284)