### PR TITLE
feat: Implement calendar API for export member events to ics file

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",
     "express-session": "^1.17.3",
+    "ics": "^3.5.0",
     "ioredis": "^5.3.1",
     "jsonwebtoken": "^9.0.0",
     "mustache": "^4.2.0",

--- a/src/application.module.ts
+++ b/src/application.module.ts
@@ -19,6 +19,7 @@ import { ProgramPackageModule } from './program-package/program-package.module';
 import { ProgramModule } from './program/program.module';
 import { PodcastModule } from './podcast/podcast.module';
 import { SwaggerConfigModule } from './swagger-config/swagger-config.module';
+import { CalendarModule } from './calendar/calendar.module';
 
 @Module({
   controllers: [ApplicationController],
@@ -75,6 +76,7 @@ import { SwaggerConfigModule } from './swagger-config/swagger-config.module';
     MediaModule,
     UtilityModule,
     // TriggerModule,
+    CalendarModule,
     OrderModule,
     ReportModule,
     ProgramPackageModule,

--- a/src/calendar/calendar.controller.ts
+++ b/src/calendar/calendar.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Param, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { createEvents, EventAttributes } from 'ics';
+
+import { APIException } from '~/api.excetion';
+
+@Controller({
+  path: 'calendars',
+  version: '2',
+})
+export class CalendarController {
+  @Get(':memberId')
+  getCalendarFileByMemberId(@Param('memberId') memberId: string, @Res() response: Response): Response {
+    if (!memberId) {
+      throw new APIException({ code: 'E_NULL_MEMBER', message: 'memberId is null or undefined' });
+    }
+
+    // TODO: Replace dummy events with database record
+    const evnets: EventAttributes[] = [
+      {
+        start: [2024, 1, 1, 8, 0],
+        duration: { minutes: 0 },
+        title: 'Happy New Year',
+        description: 'This is description',
+      },
+    ];
+    const result = createEvents(evnets);
+
+    response.set({
+      'Content-Type': 'text/calendar',
+      'Content-Disposition': `attachment; filename="${memberId}.ics"`,
+    });
+    response.send(result.value);
+    return response;
+  }
+}

--- a/src/calendar/calendar.controller.ts
+++ b/src/calendar/calendar.controller.ts
@@ -1,36 +1,31 @@
 import { Controller, Get, Param, Res } from '@nestjs/common';
 import type { Response } from 'express';
-import { createEvents, EventAttributes } from 'ics';
+import { createEvents } from 'ics';
 
 import { APIException } from '~/api.excetion';
+
+import { CalendarService } from './calendar.service';
 
 @Controller({
   path: 'calendars',
   version: '2',
 })
 export class CalendarController {
+  constructor(private calendarService: CalendarService) {}
+
   @Get(':memberId')
-  getCalendarFileByMemberId(@Param('memberId') memberId: string, @Res() response: Response): Response {
+  async getCalendarByMemberId(@Param('memberId') memberId: string, @Res() response: Response): Promise<Response> {
     if (!memberId) {
       throw new APIException({ code: 'E_NULL_MEMBER', message: 'memberId is null or undefined' });
     }
-
-    // TODO: Replace dummy events with database record
-    const evnets: EventAttributes[] = [
-      {
-        start: [2024, 1, 1, 8, 0],
-        duration: { minutes: 0 },
-        title: 'Happy New Year',
-        description: 'This is description',
-      },
-    ];
-    const result = createEvents(evnets);
+    const events = await this.calendarService.getCalendarEventsByMemberId(memberId);
+    const eventsResult = createEvents(events);
 
     response.set({
       'Content-Type': 'text/calendar',
       'Content-Disposition': `attachment; filename="${memberId}.ics"`,
     });
-    response.send(result.value);
+    response.send(eventsResult.value);
     return response;
   }
 }

--- a/src/calendar/calendar.module.ts
+++ b/src/calendar/calendar.module.ts
@@ -1,11 +1,33 @@
 import { Module } from '@nestjs/common';
 
+import { CouponInfrastructure } from '~/coupon/coupon.infra';
+import { DefinitionInfrastructure } from '~/definition/definition.infra';
+import { MemberInfrastructure } from '~/member/member.infra';
+import { MemberService } from '~/member/member.service';
+import { OrderInfrastructure } from '~/order/order.infra';
+import { OrderService } from '~/order/order.service';
+import { ProductInfrastructure } from '~/product/product.infra';
+import { SharingCodeInfrastructure } from '~/sharingCode/sharingCode.infra';
+import { VoucherInfrastructure } from '~/voucher/voucher.infra';
+
 import { CalendarController } from './calendar.controller';
+import { CalendarService } from './calendar.service';
 
 @Module({
   controllers: [CalendarController],
   imports: [],
-  providers: [],
+  providers: [
+    CalendarService,
+    CouponInfrastructure,
+    DefinitionInfrastructure,
+    MemberInfrastructure,
+    MemberService,
+    OrderInfrastructure,
+    OrderService,
+    ProductInfrastructure,
+    SharingCodeInfrastructure,
+    VoucherInfrastructure,
+  ],
   exports: [],
 })
 export class CalendarModule {}

--- a/src/calendar/calendar.module.ts
+++ b/src/calendar/calendar.module.ts
@@ -8,6 +8,7 @@ import { OrderInfrastructure } from '~/order/order.infra';
 import { OrderService } from '~/order/order.service';
 import { ProductInfrastructure } from '~/product/product.infra';
 import { SharingCodeInfrastructure } from '~/sharingCode/sharingCode.infra';
+import { CacheService } from '~/utility/cache/cache.service';
 import { VoucherInfrastructure } from '~/voucher/voucher.infra';
 
 import { CalendarController } from './calendar.controller';
@@ -17,6 +18,7 @@ import { CalendarService } from './calendar.service';
   controllers: [CalendarController],
   imports: [],
   providers: [
+    CacheService,
     CalendarService,
     CouponInfrastructure,
     DefinitionInfrastructure,

--- a/src/calendar/calendar.module.ts
+++ b/src/calendar/calendar.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { CalendarController } from './calendar.controller';
+
+@Module({
+  controllers: [CalendarController],
+  imports: [],
+  providers: [],
+  exports: [],
+})
+export class CalendarModule {}

--- a/src/calendar/calendar.service.spec.ts
+++ b/src/calendar/calendar.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventAttributes } from 'ics';
+import { v4 } from 'uuid';
+
+import { CalendarService } from './calendar.service';
+import { CouponInfrastructure } from '~/coupon/coupon.infra';
+import { DefinitionInfrastructure } from '~/definition/definition.infra';
+import { MemberTask } from '~/entity/MemberTask';
+import { MemberInfrastructure } from '~/member/member.infra';
+import { MemberService } from '~/member/member.service';
+import { OrderProduct } from '~/order/entity/order_product.entity';
+import { OrderInfrastructure } from '~/order/order.infra';
+import { OrderService } from '~/order/order.service';
+import { ProductInfrastructure } from '~/product/product.infra';
+import { SharingCodeInfrastructure } from '~/sharingCode/sharingCode.infra';
+import { VoucherInfrastructure } from '~/voucher/voucher.infra';
+import { CacheService } from '~/utility/cache/cache.service';
+
+describe('CalendarService', () => {
+  let service: CalendarService;
+  const mockCacheService = {
+    getClient: () => ({
+      get: jest.fn().mockReturnValue(new Promise((resolve) => resolve(null))),
+      set: jest.fn(),
+    }),
+  };
+  const mockMemberService = { getMemberTasks: jest.fn() };
+  const mockOrderService = { getOrderProductsByMemberId: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: CacheService,
+          useValue: mockCacheService,
+        },
+        CalendarService,
+        CouponInfrastructure,
+        DefinitionInfrastructure,
+        MemberInfrastructure,
+        {
+          provide: MemberService,
+          useValue: mockMemberService,
+        },
+        OrderInfrastructure,
+        {
+          provide: OrderService,
+          useValue: mockOrderService,
+        },
+        ProductInfrastructure,
+        SharingCodeInfrastructure,
+        VoucherInfrastructure,
+      ],
+    }).compile();
+
+    service = module.get<CalendarService>(CalendarService);
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('Method getCalendarEventsByMemberId', () => {
+    it('should return an array of calendar events', async () => {
+      const memberTask = new MemberTask();
+      const mockTaskTitle = 'Mock member task';
+      const mockTaskDescription = 'Mock member task description';
+      memberTask.memberId = v4();
+      memberTask.title = mockTaskTitle;
+      memberTask.description = mockTaskDescription;
+      memberTask.status = 'pending';
+      memberTask.dueAt = new Date('2023-12-01T00:00:00.000000');
+
+      const insertedOrderProduct = new OrderProduct();
+      insertedOrderProduct.name = 'product_name';
+      insertedOrderProduct.startedAt = new Date('2023-12-02T02:00:00.000000');
+      insertedOrderProduct.endedAt = new Date('2023-12-02T03:00:00.000000');
+
+      const memberTasks: MemberTask[] = [memberTask];
+      const orderProducts: OrderProduct[] = [insertedOrderProduct];
+      mockMemberService.getMemberTasks.mockReturnValue(new Promise((resolve) => resolve(memberTasks)));
+      mockOrderService.getOrderProductsByMemberId.mockReturnValue(new Promise((resolve) => resolve(orderProducts)));
+
+      const events: EventAttributes[] = await service.getCalendarEventsByMemberId('fake_member_id');
+      expect(events.length).toEqual(2);
+      expect(events[0].start).toEqual([2023, 12, 1, 0, 0]);
+      expect(events[0].title).toEqual(mockTaskTitle);
+      expect(events[0].description).toEqual(mockTaskDescription);
+      expect(events[1].start).toEqual([2023, 12, 2, 2, 0]);
+    });
+  });
+});

--- a/src/calendar/calendar.service.ts
+++ b/src/calendar/calendar.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { EventAttributes } from 'ics';
+
+import { MemberService } from '~/member/member.service';
+import { OrderService } from '~/order/order.service';
+
+@Injectable()
+export class CalendarService {
+  constructor(private readonly memberService: MemberService, private readonly orderService: OrderService) {}
+
+  async getCalendarEventsByMemberId(memberId: string): Promise<EventAttributes[]> {
+    const tasks = await this.memberService.getMemberTasks(memberId);
+    const taskEvents: EventAttributes[] = tasks.map((task) => {
+      return {
+        start: this.dateToIcsDateArray(task.dueAt),
+        title: task.title,
+        description: task.description || '',
+        duration: { minutes: 0 },
+      };
+    });
+
+    const orderProducts = await this.orderService.getOrderProductsByMemberId(memberId, 'AppointmentPlan');
+    const orderProductEvents: EventAttributes[] = orderProducts.map((orderProduct) => {
+      return {
+        start: this.dateToIcsDateArray(orderProduct.startedAt),
+        end: this.dateToIcsDateArray(orderProduct.endedAt),
+        title: orderProduct.name,
+        description: orderProduct.description || '',
+      };
+    });
+
+    const events: EventAttributes[] = taskEvents.concat(orderProductEvents);
+    return events;
+  }
+
+  private dateToIcsDateArray(date: Date): [number, number, number, number, number] {
+    return [date.getFullYear(), date.getMonth() + 1, date.getDate(), date.getHours(), date.getMinutes()];
+  }
+}

--- a/src/calendar/calendar.service.ts
+++ b/src/calendar/calendar.service.ts
@@ -1,14 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { EventAttributes } from 'ics';
 
+import { CacheService } from '~/utility/cache/cache.service';
 import { MemberService } from '~/member/member.service';
 import { OrderService } from '~/order/order.service';
 
 @Injectable()
 export class CalendarService {
-  constructor(private readonly memberService: MemberService, private readonly orderService: OrderService) {}
+  private readonly cacheKeyPrefix = 'calendar_';
+  constructor(
+    private readonly cacheService: CacheService,
+    private readonly memberService: MemberService,
+    private readonly orderService: OrderService,
+  ) {}
 
   async getCalendarEventsByMemberId(memberId: string): Promise<EventAttributes[]> {
+    const redisCli = this.cacheService.getClient();
+    const cachedEvents = await redisCli.get(`${this.cacheKeyPrefix}${memberId}`).then((result) => {
+      return JSON.parse(result);
+    });
+    if (cachedEvents) {
+      return cachedEvents;
+    }
+
     const tasks = await this.memberService.getMemberTasks(memberId);
     const taskEvents: EventAttributes[] = tasks.map((task) => {
       return {
@@ -30,6 +44,7 @@ export class CalendarService {
     });
 
     const events: EventAttributes[] = taskEvents.concat(orderProductEvents);
+    redisCli.set(`${this.cacheKeyPrefix}${memberId}`, JSON.stringify(events), 'EX', 3600); // Cache expire in 60 mins.
     return events;
   }
 

--- a/src/calendar/calendar.service.ts
+++ b/src/calendar/calendar.service.ts
@@ -26,6 +26,7 @@ export class CalendarService {
     const tasks = await this.memberService.getMemberTasks(memberId);
     const taskEvents: EventAttributes[] = tasks.map((task) => {
       return {
+        uid: task.id,
         start: this.dateToIcsDateArray(task.dueAt),
         title: task.title,
         description: task.description || '',
@@ -36,6 +37,7 @@ export class CalendarService {
     const orderProducts = await this.orderService.getOrderProductsByMemberId(memberId, 'AppointmentPlan');
     const orderProductEvents: EventAttributes[] = orderProducts.map((orderProduct) => {
       return {
+        uid: orderProduct.id,
         start: this.dateToIcsDateArray(orderProduct.startedAt),
         end: this.dateToIcsDateArray(orderProduct.endedAt),
         title: orderProduct.name,

--- a/src/calendar/calendar.service.ts
+++ b/src/calendar/calendar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { EventAttributes } from 'ics';
+import { EventAttributes, convertTimestampToArray } from 'ics';
 
 import { CacheService } from '~/utility/cache/cache.service';
 import { MemberService } from '~/member/member.service';
@@ -27,7 +27,7 @@ export class CalendarService {
     const taskEvents: EventAttributes[] = tasks.map((task) => {
       return {
         uid: task.id,
-        start: this.dateToIcsDateArray(task.dueAt),
+        start: convertTimestampToArray(task.dueAt.getTime(), 'local'),
         title: task.title,
         description: task.description || '',
         duration: { minutes: 0 },
@@ -38,8 +38,8 @@ export class CalendarService {
     const orderProductEvents: EventAttributes[] = orderProducts.map((orderProduct) => {
       return {
         uid: orderProduct.id,
-        start: this.dateToIcsDateArray(orderProduct.startedAt),
-        end: this.dateToIcsDateArray(orderProduct.endedAt),
+        start: convertTimestampToArray(orderProduct.startedAt.getTime(), 'local'),
+        end: convertTimestampToArray(orderProduct.endedAt.getTime(), 'local'),
         title: orderProduct.name,
         description: orderProduct.description || '',
       };
@@ -48,9 +48,5 @@ export class CalendarService {
     const events: EventAttributes[] = taskEvents.concat(orderProductEvents);
     redisCli.set(`${this.cacheKeyPrefix}${memberId}`, JSON.stringify(events), 'EX', 3600); // Cache expire in 60 mins.
     return events;
-  }
-
-  private dateToIcsDateArray(date: Date): [number, number, number, number, number] {
-    return [date.getFullYear(), date.getMonth() + 1, date.getDate(), date.getHours(), date.getMinutes()];
   }
 }

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -181,6 +181,12 @@ export class MemberInfrastructure {
     return founds;
   }
 
+  async getMemberTasks(memberId: string, manager: EntityManager): Promise<Array<MemberTask>> {
+    const memberTaskRepo = manager.getRepository(MemberTask);
+    const tasks = await memberTaskRepo.findBy({ memberId });
+    return tasks;
+  }
+
   async getLoginMemberMetadata(memberId: string, manager: EntityManager): Promise<Array<LoginMemberMetadata>> {
     const builder = manager
       .createQueryBuilder()

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -350,9 +350,6 @@ export class MemberService {
   }
 
   async getMemberTasks(memberId: string): Promise<Array<MemberTask>> {
-    const tasks = this.entityManager.getRepository(MemberTask).find({
-      where: { member: { id: memberId } },
-    });
-    return tasks;
+    return this.memberInfra.getMemberTasks(memberId, this.entityManager);
   }
 }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -9,6 +9,7 @@ import { DefinitionInfrastructure } from '~/definition/definition.infra';
 import { Property } from '~/definition/entity/property.entity';
 import { Category } from '~/definition/entity/category.entity';
 import { Tag } from '~/definition/entity/tag.entity';
+import { MemberTask } from '~/entity/MemberTask';
 import { isNullString } from '~/utils';
 
 import { MemberCsvHeaderMapping } from './class/csvHeaderMapping';
@@ -348,4 +349,10 @@ export class MemberService {
     return this.memberInfra.deleteMemberByEmail(appId, email, this.entityManager);
   }
 
+  async getMemberTasks(memberId: string): Promise<Array<MemberTask>> {
+    const tasks = this.entityManager.getRepository(MemberTask).find({
+      where: { member: { id: memberId } },
+    });
+    return tasks;
+  }
 }

--- a/src/order/order.infra.ts
+++ b/src/order/order.infra.ts
@@ -94,4 +94,21 @@ export class OrderInfrastructure {
     });
     return orderDiscounts;
   }
+
+  async getOrderProductsByMemberId(
+    memberId: string,
+    manager: EntityManager,
+    productType?: string,
+  ): Promise<Array<OrderProduct>> {
+    const orderProductRepo = manager.getRepository(OrderProduct);
+    const orderProducts = await orderProductRepo.find({
+      where: {
+        order: {
+          memberId: memberId,
+        },
+        ...(productType && { product: { type: productType } }),
+      },
+    });
+    return orderProducts;
+  }
 }

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -576,4 +576,16 @@ export class OrderService {
     }
     return isEmpty(targets) ? null : targets;
   }
+
+  public async getOrderProductsByMemberId(memberId: string, productType?: string): Promise<OrderProduct[]> {
+    const orderProducts = await this.entityManager.getRepository(OrderProduct).find({
+      where: {
+        order: {
+          memberId: memberId,
+        },
+        ...(productType && { product: { type: productType } }),
+      },
+    });
+    return orderProducts;
+  }
 }

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -578,14 +578,6 @@ export class OrderService {
   }
 
   public async getOrderProductsByMemberId(memberId: string, productType?: string): Promise<OrderProduct[]> {
-    const orderProducts = await this.entityManager.getRepository(OrderProduct).find({
-      where: {
-        order: {
-          memberId: memberId,
-        },
-        ...(productType && { product: { type: productType } }),
-      },
-    });
-    return orderProducts;
+    return this.orderInfra.getOrderProductsByMemberId(memberId, this.entityManager, productType);
   }
 }

--- a/test/calendar/controller.e2e-spec.ts
+++ b/test/calendar/controller.e2e-spec.ts
@@ -1,0 +1,227 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { createEvent } from 'ics';
+import request from 'supertest';
+import { EntityManager, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { ApiExceptionFilter } from '~/api.filter';
+import { ApplicationModule } from '~/application.module';
+import { App } from '~/app/entity/app.entity';
+import { AppHost } from '~/app/entity/app_host.entity';
+import { AppSecret } from '~/app/entity/app_secret.entity';
+import { AppSetting } from '~/app/entity/app_setting.entity';
+import { AppointmentPlan } from '~/entity/AppointmentPlan';
+import { AppPlan } from '~/entity/AppPlan';
+import { Currency } from '~/entity/Currency';
+import { MemberTask } from '~/entity/MemberTask';
+import { Product } from '~/entity/Product';
+import { Role } from '~/entity/Role';
+import { Member } from '~/member/entity/member.entity';
+import { OrderLog } from '~/order/entity/order_log.entity';
+import { OrderProduct } from '~/order/entity/order_product.entity';
+import { CacheService } from '~/utility/cache/cache.service';
+
+import { role, app, appPlan, appSecret, appSetting, appHost, currency } from '../data';
+
+describe('CanlendarController (e2e)', () => {
+  let application: INestApplication;
+  let cacheService: CacheService;
+  let manager: EntityManager;
+  let roleRepo: Repository<Role>;
+  let appPlanRepo: Repository<AppPlan>;
+  let appRepo: Repository<App>;
+  let appHostRepo: Repository<AppHost>;
+  let appSecretRepo: Repository<AppSecret>;
+  let appSettingRepo: Repository<AppSetting>;
+  let appointmentPlanRepo: Repository<AppointmentPlan>;
+  let currencyRepo: Repository<Currency>;
+  let memberRepo: Repository<Member>;
+  let memberTaskRepo: Repository<MemberTask>;
+  let orderLogRepo: Repository<OrderLog>;
+  let orderProductRepo: Repository<OrderProduct>;
+  let productRepo: Repository<Product>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    application = module.createNestApplication();
+    application.useGlobalPipes(new ValidationPipe()).useGlobalFilters(new ApiExceptionFilter());
+    cacheService = application.get(CacheService);
+    manager = application.get<EntityManager>(getEntityManagerToken());
+    roleRepo = manager.getRepository(Role);
+    appPlanRepo = manager.getRepository(AppPlan);
+    appRepo = manager.getRepository(App);
+    appHostRepo = manager.getRepository(AppHost);
+    appSecretRepo = manager.getRepository(AppSecret);
+    appSettingRepo = manager.getRepository(AppSetting);
+    appointmentPlanRepo = manager.getRepository(AppointmentPlan);
+    currencyRepo = manager.getRepository(Currency);
+    memberRepo = manager.getRepository(Member);
+    memberTaskRepo = manager.getRepository(MemberTask);
+    orderLogRepo = manager.getRepository(OrderLog);
+    orderProductRepo = manager.getRepository(OrderProduct);
+    productRepo = manager.getRepository(Product);
+
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberRepo.delete({});
+    await currencyRepo.delete({});
+    await appSettingRepo.delete({});
+    await appSecretRepo.delete({});
+    await appHostRepo.delete({});
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+    await roleRepo.delete({});
+    await cacheService.getClient().flushall();
+
+    await currencyRepo.save(currency);
+    await roleRepo.save(role);
+    await appPlanRepo.save(appPlan);
+    await appRepo.save(app);
+    await appHostRepo.save(appHost);
+    await appSecretRepo.save(appSecret);
+    await appSettingRepo.save(appSetting);
+
+    await application.init();
+  });
+
+  afterEach(async () => {
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberRepo.delete({});
+    await currencyRepo.delete({});
+    await appHostRepo.delete({});
+    await appSettingRepo.delete({});
+    await appSecretRepo.delete({});
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+    await roleRepo.delete({});
+    await cacheService.getClient().flushall();
+    await application.close();
+  });
+
+  describe('/calendars/:memberId (GET)', () => {
+    it('Should get no result with fake member id successfully', async () => {
+      const response = await request(application.getHttpServer())
+        .get('/calendars/fake_member_id')
+        .set('host', appHost.host)
+        .expect(200);
+      expect(response.headers['content-type']).toEqual('text/calendar; charset=utf-8');
+      expect(response.headers['content-disposition']).toEqual('attachment; filename="fake_member_id.ics"');
+    });
+
+    const member = new Member();
+    member.id = v4();
+    member.appId = app.id;
+    member.email = 'calendar@example.com';
+    member.username = 'calendar';
+    member.role = role.name;
+    member.name = 'calendar user';
+
+    const memberTask = new MemberTask();
+    memberTask.memberId = member.id;
+    memberTask.title = 'Mock member task';
+    memberTask.priority = 'high';
+    memberTask.description = 'Mock member task description';
+    memberTask.status = 'pending';
+    memberTask.dueAt = new Date('2023-12-01T00:00:00.000000');
+
+    const orderLog = new OrderLog();
+    orderLog.id = 'TES1234567890';
+    orderLog.memberId = member.id;
+    orderLog.status = 'SUCCESS';
+    orderLog.appId = app.id;
+    orderLog.invoiceOptions = {};
+
+    const appointmentPlan = new AppointmentPlan();
+    appointmentPlan.id = v4();
+    appointmentPlan.creator = member;
+    appointmentPlan.title = 'appointment-plan';
+    appointmentPlan.description = 'appointment plan description';
+    appointmentPlan.price = 1;
+    appointmentPlan.duration = 30;
+    appointmentPlan.currency = currency;
+
+    const appointmentPlanProduct = new Product();
+    appointmentPlanProduct.type = 'AppointmentPlan';
+    appointmentPlanProduct.id = `${appointmentPlanProduct.type}_${appointmentPlan.id}`;
+    appointmentPlanProduct.target = appointmentPlan.id;
+
+    const orderProduct = new OrderProduct();
+    orderProduct.order = orderLog;
+    orderProduct.product = appointmentPlanProduct;
+    orderProduct.name = 'appointment product';
+    orderProduct.description = 'appointment product description';
+    orderProduct.price = 20;
+    orderProduct.currency = currency;
+    orderProduct.startedAt = new Date('2023-12-02T01:00:00.000000');
+    orderProduct.endedAt = new Date('2023-12-02T02:00:00.000000');
+
+    it('Should get member task calendar with member id successfully', async () => {
+      await memberRepo.save(member);
+      await memberTaskRepo.save(memberTask);
+
+      const response = await request(application.getHttpServer())
+        .get(`/calendars/${member.id}`)
+        .set('host', appHost.host)
+        .expect(200);
+
+      expect(response.headers['content-type']).toEqual('text/calendar; charset=utf-8');
+      expect(response.headers['content-disposition']).toEqual(`attachment; filename=\"${member.id}.ics\"`);
+
+      const memberCalendar = createEvent({
+        start: [2023, 12, 1, 0, 0],
+        title: memberTask.title,
+        description: memberTask.description,
+        duration: { minutes: 0 },
+      }).value.split('\r\n');
+      const responseText = response.text.split('\r\n');
+
+      for (let i = 0; i < responseText.length; i++) {
+        if (!responseText[i].startsWith('UID:')) {
+          expect(responseText[i]).toEqual(memberCalendar[i]);
+        }
+      }
+    });
+
+    it('Should get appointment plan calendar with member id successfully', async () => {
+      await memberRepo.save(member);
+      await orderLogRepo.save(orderLog);
+      await appointmentPlanRepo.save(appointmentPlan);
+      await orderProductRepo.save(orderProduct);
+      await productRepo.save(appointmentPlanProduct);
+
+      const response = await request(application.getHttpServer())
+        .get(`/calendars/${member.id}`)
+        .set('host', appHost.host)
+        .expect(200);
+
+      expect(response.headers['content-type']).toEqual('text/calendar; charset=utf-8');
+      expect(response.headers['content-disposition']).toEqual(`attachment; filename=\"${member.id}.ics\"`);
+
+      const memberCalendar = createEvent({
+        start: [2023, 12, 2, 1, 0],
+        end: [2023, 12, 2, 2, 0],
+        title: orderProduct.name,
+        description: orderProduct.description,
+      }).value.split('\r\n');
+      const responseText = response.text.split('\r\n');
+
+      for (let i = 0; i < responseText.length; i++) {
+        if (!responseText[i].startsWith('UID:')) {
+          expect(responseText[i]).toEqual(memberCalendar[i]);
+        }
+      }
+    });
+  });
+});

--- a/test/calendar/controller.e2e-spec.ts
+++ b/test/calendar/controller.e2e-spec.ts
@@ -129,6 +129,7 @@ describe('CanlendarController (e2e)', () => {
     member.name = 'calendar user';
 
     const memberTask = new MemberTask();
+    memberTask.id = v4();
     memberTask.memberId = member.id;
     memberTask.title = 'Mock member task';
     memberTask.priority = 'high';
@@ -158,6 +159,7 @@ describe('CanlendarController (e2e)', () => {
     appointmentPlanProduct.target = appointmentPlan.id;
 
     const orderProduct = new OrderProduct();
+    orderProduct.id = v4();
     orderProduct.order = orderLog;
     orderProduct.product = appointmentPlanProduct;
     orderProduct.name = 'appointment product';
@@ -180,6 +182,7 @@ describe('CanlendarController (e2e)', () => {
       expect(response.headers['content-disposition']).toEqual(`attachment; filename=\"${member.id}.ics\"`);
 
       const memberCalendar = createEvent({
+        uid: memberTask.id,
         start: [2023, 12, 1, 0, 0],
         title: memberTask.title,
         description: memberTask.description,
@@ -188,9 +191,7 @@ describe('CanlendarController (e2e)', () => {
       const responseText = response.text.split('\r\n');
 
       for (let i = 0; i < responseText.length; i++) {
-        if (!responseText[i].startsWith('UID:')) {
-          expect(responseText[i]).toEqual(memberCalendar[i]);
-        }
+        expect(responseText[i]).toEqual(memberCalendar[i]);
       }
     });
 
@@ -210,6 +211,7 @@ describe('CanlendarController (e2e)', () => {
       expect(response.headers['content-disposition']).toEqual(`attachment; filename=\"${member.id}.ics\"`);
 
       const memberCalendar = createEvent({
+        uid: orderProduct.id,
         start: [2023, 12, 2, 1, 0],
         end: [2023, 12, 2, 2, 0],
         title: orderProduct.name,
@@ -218,9 +220,7 @@ describe('CanlendarController (e2e)', () => {
       const responseText = response.text.split('\r\n');
 
       for (let i = 0; i < responseText.length; i++) {
-        if (!responseText[i].startsWith('UID:')) {
-          expect(responseText[i]).toEqual(memberCalendar[i]);
-        }
+        expect(responseText[i]).toEqual(memberCalendar[i]);
       }
     });
   });

--- a/test/calendar/service.e2e-spec.ts
+++ b/test/calendar/service.e2e-spec.ts
@@ -1,0 +1,175 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { DurationObject, EventAttributes } from 'ics';
+import { EntityManager, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { App } from '~/app/entity/app.entity';
+import { ApplicationModule } from '~/application.module';
+import { CalendarService } from '~/calendar/calendar.service';
+import { AppointmentPlan } from '~/entity/AppointmentPlan';
+import { AppPlan } from '~/entity/AppPlan';
+import { Currency } from '~/entity/Currency';
+import { MemberTask } from '~/entity/MemberTask';
+import { Product } from '~/entity/Product';
+import { Role } from '~/entity/Role';
+import { Member } from '~/member/entity/member.entity';
+import { OrderLog } from '~/order/entity/order_log.entity';
+import { OrderProduct } from '~/order/entity/order_product.entity';
+import { CacheService } from '~/utility/cache/cache.service';
+
+import { app, appPlan, currency, role } from '../data';
+
+describe('CalendarService (e2e)', () => {
+  let application: INestApplication;
+  let service: CalendarService;
+  let cacheService: CacheService;
+
+  let manager: EntityManager;
+  let roleRepo: Repository<Role>;
+  let currencyRepo: Repository<Currency>;
+  let appointmentPlanRepo: Repository<AppointmentPlan>;
+  let productRepo: Repository<Product>;
+  let memberRepo: Repository<Member>;
+  let memberTaskRepo: Repository<MemberTask>;
+  let orderLogRepo: Repository<OrderLog>;
+  let orderProductRepo: Repository<OrderProduct>;
+  let appPlanRepo: Repository<AppPlan>;
+  let appRepo: Repository<App>;
+
+  beforeEach(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    application = moduleFixture.createNestApplication();
+    service = application.get(CalendarService);
+    cacheService = application.get(CacheService);
+
+    manager = application.get<EntityManager>(getEntityManagerToken());
+    roleRepo = manager.getRepository(Role);
+    currencyRepo = manager.getRepository(Currency);
+    appointmentPlanRepo = manager.getRepository(AppointmentPlan);
+    productRepo = manager.getRepository(Product);
+    memberRepo = manager.getRepository(Member);
+    memberTaskRepo = manager.getRepository(MemberTask);
+    orderLogRepo = manager.getRepository(OrderLog);
+    orderProductRepo = manager.getRepository(OrderProduct);
+    appPlanRepo = manager.getRepository(AppPlan);
+    appRepo = manager.getRepository(App);
+
+    await roleRepo.delete({});
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberRepo.delete({});
+    await currencyRepo.delete({});
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+    await cacheService.getClient().flushall();
+
+    await appPlanRepo.save(appPlan);
+    await appRepo.save(app);
+    await roleRepo.save(role);
+    await currencyRepo.save(currency);
+    await application.init();
+  });
+
+  afterEach(async () => {
+    await roleRepo.delete({});
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberTaskRepo.delete({});
+    await memberRepo.delete({});
+    await currencyRepo.delete({});
+    await cacheService.getClient().flushall();
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+    await application.close();
+  });
+
+  describe('Method getCalendarEventsByMemberId', () => {
+    const member = new Member();
+    member.id = v4();
+    member.appId = app.id;
+    member.email = 'owner@example.com';
+    member.username = 'owner';
+    member.role = role.name;
+    member.name = 'firstMember';
+
+    const memberTask = new MemberTask();
+    memberTask.memberId = member.id;
+    memberTask.title = 'Mock member task';
+    memberTask.priority = 'high';
+    memberTask.description = 'Mock member task description';
+    memberTask.status = 'pending';
+    memberTask.dueAt = new Date('2023-12-01T00:00:00.000000');
+
+    const orderLog = new OrderLog();
+    orderLog.id = 'TES1234567890';
+    orderLog.memberId = member.id;
+    orderLog.status = 'SUCCESS';
+    orderLog.appId = app.id;
+    orderLog.invoiceOptions = {};
+
+    const appointmentPlan = new AppointmentPlan();
+    appointmentPlan.id = v4();
+    appointmentPlan.creator = member;
+    appointmentPlan.title = 'appointment-plan';
+    appointmentPlan.description = 'appointment plan description';
+    appointmentPlan.price = 1;
+    appointmentPlan.duration = 30;
+    appointmentPlan.currency = currency;
+
+    const appointmentPlanProduct = new Product();
+    appointmentPlanProduct.type = 'AppointmentPlan';
+    appointmentPlanProduct.id = `${appointmentPlanProduct.type}_${appointmentPlan.id}`;
+    appointmentPlanProduct.target = appointmentPlan.id;
+
+    const orderProduct = new OrderProduct();
+    orderProduct.order = orderLog;
+    orderProduct.product = appointmentPlanProduct;
+    orderProduct.name = 'appointment product';
+    orderProduct.description = 'appointment product description';
+    orderProduct.price = 20;
+    orderProduct.currency = currency;
+    orderProduct.startedAt = new Date('2023-12-02T01:00:00.000000');
+    orderProduct.endedAt = new Date('2023-12-02T02:00:00.000000');
+
+    it('Should get member task calendar event with specified memberId', async () => {
+      await memberRepo.save(member);
+      await memberTaskRepo.save(memberTask);
+
+      const events: EventAttributes[] = await service.getCalendarEventsByMemberId(member.id);
+      expect(events.length).toBe(1);
+
+      const memberTaskEvent = events[0] as EventAttributes & { duration: DurationObject };
+      expect(memberTaskEvent.start).toEqual([2023, 12, 1, 0, 0]);
+      expect(memberTaskEvent.duration.minutes).toEqual(0);
+      expect(memberTaskEvent.title).toEqual(memberTask.title);
+      expect(memberTaskEvent.description).toEqual(memberTask.description);
+    });
+
+    it('Should get order product calendar event with specified memberId', async () => {
+      await memberRepo.save(member);
+      await orderLogRepo.save(orderLog);
+      await appointmentPlanRepo.save(appointmentPlan);
+      await orderProductRepo.save(orderProduct);
+      await productRepo.save(appointmentPlanProduct);
+
+      const events: EventAttributes[] = await service.getCalendarEventsByMemberId(member.id);
+      expect(events.length).toBe(1);
+
+      const orderProductEvent = events[0] as EventAttributes & { end: number };
+      expect(orderProductEvent.start).toEqual([2023, 12, 2, 1, 0]);
+      expect(orderProductEvent.end).toEqual([2023, 12, 2, 2, 0]);
+      expect(orderProductEvent.title).toEqual(orderProduct.name);
+      expect(orderProductEvent.description).toEqual(orderProduct.description);
+    });
+  });
+});

--- a/test/member/service.e2e-spec.ts
+++ b/test/member/service.e2e-spec.ts
@@ -7,6 +7,7 @@ import { Test } from '@nestjs/testing';
 
 import { ApplicationModule } from '~/application.module';
 import { AppPlan } from '~/entity/AppPlan';
+import { MemberTask } from '~/entity/MemberTask';
 import { Category } from '~/definition/entity/category.entity';
 import { Property } from '~/definition/entity/property.entity';
 import { Tag } from '~/definition/entity/tag.entity';
@@ -29,6 +30,7 @@ describe('MemberService (e2e)', () => {
   let memberCategoryRepo: Repository<MemberCategory>;
   let memberPropertyRepo: Repository<MemberProperty>;
   let memberTagRepo: Repository<MemberTag>;
+  let memberTaskRepo: Repository<MemberTask>;
   let memberRepo: Repository<Member>;
   let appPlanRepo: Repository<AppPlan>;
   let appRepo: Repository<App>;
@@ -49,6 +51,7 @@ describe('MemberService (e2e)', () => {
     memberCategoryRepo = manager.getRepository(MemberCategory);
     memberPropertyRepo = manager.getRepository(MemberProperty);
     memberTagRepo = manager.getRepository(MemberTag);
+    memberTaskRepo = manager.getRepository(MemberTask);
     memberRepo = manager.getRepository(Member);
     appPlanRepo = manager.getRepository(AppPlan);
     appRepo = manager.getRepository(App);
@@ -60,6 +63,7 @@ describe('MemberService (e2e)', () => {
     await memberCategoryRepo.delete({});
     await memberPropertyRepo.delete({});
     await memberTagRepo.delete({});
+    await memberTaskRepo.delete({});
     await memberRepo.delete({});
     await appRepo.delete({});
     await appPlanRepo.delete({});
@@ -83,6 +87,7 @@ describe('MemberService (e2e)', () => {
     await memberCategoryRepo.delete({});
     await memberPropertyRepo.delete({});
     await memberTagRepo.delete({});
+    await memberTaskRepo.delete({});
     await memberRepo.delete({});
     await categoryRepo.delete({});
     await propertyRepo.delete({});
@@ -797,6 +802,53 @@ describe('MemberService (e2e)', () => {
         await testField('tags', 'blank', setBlank, toExpect, false),
           await testField('tags', 'undefined', setUndefined, toExpect, false);
       });
+    });
+  });
+
+  describe('Method getMemberTasks', () => {
+    const existingMemberId = v4();
+    const insertedMember = new Member();
+    insertedMember.appId = app.id;
+    insertedMember.id = existingMemberId;
+    insertedMember.name = 'member_task_test';
+    insertedMember.username = 'acc_member_task_test';
+    insertedMember.email = `mail_member_task_test@example.com`;
+    insertedMember.role = 'general-member';
+    insertedMember.star = 0;
+    insertedMember.createdAt = new Date();
+    insertedMember.loginedAt = new Date();
+
+    const insertedMemberTask = new MemberTask();
+    insertedMemberTask.memberId = insertedMember.id;
+    insertedMemberTask.title = 'title';
+    insertedMemberTask.priority = 'high';
+    insertedMemberTask.status = 'pending';
+
+    const insertedMemberTask2 = new MemberTask();
+    insertedMemberTask2.memberId = insertedMember.id;
+    insertedMemberTask2.title = 'title_2';
+    insertedMemberTask2.priority = 'high';
+    insertedMemberTask2.status = 'pending';
+
+    it('Should get no any member tasks with fake memberId', async () => {
+      const fakeMemberId = v4();
+      await memberRepo.save(insertedMember);
+      await manager.save(insertedMemberTask);
+      await manager.save(insertedMemberTask2);
+
+      const fakeMemberTasks = await service.getMemberTasks(fakeMemberId);
+      expect(fakeMemberTasks.length).toBe(0);
+    });
+
+    it('Should get member tasks with specified memberId', async () => {
+      await memberRepo.save(insertedMember);
+      await manager.save(insertedMemberTask);
+      await manager.save(insertedMemberTask2);
+
+      const existingMemberTasks = await service.getMemberTasks(existingMemberId);
+      expect(existingMemberTasks.length).toBe(2);
+      expect(existingMemberTasks[0].memberId).toBe(existingMemberId);
+      expect(existingMemberTasks[1].memberId).toBe(existingMemberId);
     });
   });
 });

--- a/test/order/service.e2e-spec.ts
+++ b/test/order/service.e2e-spec.ts
@@ -1,0 +1,134 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { App } from '~/app/entity/app.entity';
+import { ApplicationModule } from '~/application.module';
+import { AppointmentPlan } from '~/entity/AppointmentPlan';
+import { AppPlan } from '~/entity/AppPlan';
+import { Currency } from '~/entity/Currency';
+import { Product } from '~/entity/Product';
+import { Role } from '~/entity/Role';
+import { Member } from '~/member/entity/member.entity';
+import { OrderService } from '~/order/order.service';
+import { OrderLog } from '~/order/entity/order_log.entity';
+import { OrderProduct } from '~/order/entity/order_product.entity';
+
+import { app, appPlan, currency, role } from '../data';
+
+describe('OrderService (e2e)', () => {
+  let application: INestApplication;
+  let service: OrderService;
+  let manager: EntityManager;
+
+  let appointmentPlanRepo: Repository<AppointmentPlan>;
+  let appPlanRepo: Repository<AppPlan>;
+  let appRepo: Repository<App>;
+  let currencyRepo: Repository<Currency>;
+  let memberRepo: Repository<Member>;
+  let orderLogRepo: Repository<OrderLog>;
+  let orderProductRepo: Repository<OrderProduct>;
+  let productRepo: Repository<Product>;
+  let roleRepo: Repository<Role>;
+
+  beforeEach(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    application = moduleFixture.createNestApplication();
+    service = application.get(OrderService);
+    manager = application.get<EntityManager>(getEntityManagerToken());
+
+    appointmentPlanRepo = manager.getRepository(AppointmentPlan);
+    appPlanRepo = manager.getRepository(AppPlan);
+    appRepo = manager.getRepository(App);
+    currencyRepo = manager.getRepository(Currency);
+    memberRepo = manager.getRepository(Member);
+    orderLogRepo = manager.getRepository(OrderLog);
+    orderProductRepo = manager.getRepository(OrderProduct);
+    productRepo = manager.getRepository(Product);
+    roleRepo = manager.getRepository(Role);
+
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberRepo.delete({});
+    await roleRepo.delete({});
+    await currencyRepo.delete({});
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+
+    await appPlanRepo.save(appPlan);
+    await appRepo.save(app);
+    await roleRepo.save(role);
+    await currencyRepo.save(currency);
+    await application.init();
+  });
+
+  afterEach(async () => {
+    await appointmentPlanRepo.delete({});
+    await orderProductRepo.delete({});
+    await orderLogRepo.delete({});
+    await productRepo.delete({});
+    await memberRepo.delete({});
+    await roleRepo.delete({});
+    await currencyRepo.delete({});
+    await appRepo.delete({});
+    await appPlanRepo.delete({});
+    await application.close();
+  });
+
+  describe('Method getOrderProductsByMemberId', () => {
+    const member = new Member();
+    member.id = v4();
+    member.appId = app.id;
+    member.email = 'owner@example.com';
+    member.username = 'owner';
+    member.role = role.name;
+    member.name = 'firstMember';
+
+    const orderLog = new OrderLog();
+    orderLog.id = 'TES1234567890';
+    orderLog.memberId = member.id;
+    orderLog.status = 'SUCCESS';
+    orderLog.appId = app.id;
+    orderLog.invoiceOptions = {};
+
+    const appointmentPlan = new AppointmentPlan();
+    appointmentPlan.id = v4();
+    appointmentPlan.creator = member;
+    appointmentPlan.title = 'appointment-plan';
+    appointmentPlan.description = 'appointment plan description';
+    appointmentPlan.price = 1;
+    appointmentPlan.duration = 30;
+    appointmentPlan.currency = currency;
+
+    const appointmentPlanProduct = new Product();
+    appointmentPlanProduct.type = 'AppointmentPlan';
+    appointmentPlanProduct.id = `${appointmentPlanProduct.type}_${appointmentPlan.id}`;
+    appointmentPlanProduct.target = appointmentPlan.id;
+
+    const orderProduct = new OrderProduct();
+    orderProduct.order = orderLog;
+    orderProduct.product = appointmentPlanProduct;
+    orderProduct.name = 'appointment product';
+    orderProduct.price = 20;
+    orderProduct.currency = currency;
+
+    it('Should get order products with specified memberId', async () => {
+      await memberRepo.save(member);
+      await orderLogRepo.save(orderLog);
+      await appointmentPlanRepo.save(appointmentPlan);
+      await orderProductRepo.save(orderProduct);
+      await productRepo.save(appointmentPlanProduct);
+
+      const orderProducts: OrderProduct[] = await service.getOrderProductsByMemberId(member.id);
+      expect(orderProducts.length).toBe(1);
+      expect(orderProducts[0].orderId).toBe(orderLog.id);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4313,6 +4313,14 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ics@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/ics/-/ics-3.5.0.tgz#d63f5d22a71c6fce71f046cd8f2b1ec71a5d2731"
+  integrity sha512-4jXcwh0cyGyE9FaoHE/zFjpac0t6CIPGLQ5rPr9x/Uj3YmVDIIYLa01lpgp1GsUGdhsEwa/PgCm1/kocRItOEg==
+  dependencies:
+    nanoid "^3.1.23"
+    yup "^1.2.0"
+
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -5426,6 +5434,11 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nanoid@^3.1.23:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -5994,6 +6007,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -6746,6 +6764,11 @@ through@^2.3.6, through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -6774,6 +6797,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -6921,6 +6949,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@^1.6.4, type-is@~1.6.18:
   version "1.6.18"
@@ -7294,3 +7327,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.3.2.tgz#afffc458f1513ed386e6aaf4bcaa4e67a9e270dc"
+  integrity sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
#### Introduce 
- Create an API to return member's events in ics format
- Ensure the API response could be added to Google Calendar
- Calendar API endpoint: `GET /api/v2/calendars/:memberId` 
- Ensure the calendar events will not duplicate after re-syncing.