### PR TITLE
Feature/proter runner issues fix

### DIFF
--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -296,7 +296,15 @@ export class MemberInfrastructure {
 
   async updateMemberLoginDate(memberId: string, loginedAt: Date, entityManager: EntityManager): Promise<void> {
     const memberRepo = entityManager.getRepository(Member);
-    await memberRepo.update(memberId, { loginedAt });
+    try {
+      const updateResult = await memberRepo.update(memberId, { loginedAt });
+
+      if (updateResult?.affected === 0) {
+        console.error(`No records updated for memberId: ${memberId}. Member might not exist.`);
+      }
+    } catch (error) {
+      console.error(`Error updating login date for memberId: ${memberId}`, error);
+    }
   }
 
   private getMemberPropertyQueryBuilderByCondition(entityManager: EntityManager, conditions: FindOptionsWhere<Member>) {

--- a/src/program/entity/ProgramContentLog.ts
+++ b/src/program/entity/ProgramContentLog.ts
@@ -29,6 +29,9 @@ export class ProgramContentLog {
   @Column('numeric', { name: 'ended_at' })
   endedAt: number;
 
+  @Column('text', { name: 'program_content_id' })
+  programContentId: string;
+
   @ManyToOne(() => Member, (member) => member.programContentLogs, {
     onDelete: 'RESTRICT',
     onUpdate: 'RESTRICT',

--- a/src/program/porter-program.service.ts
+++ b/src/program/porter-program.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { EntityManager, In } from 'typeorm';
+import { CacheService } from '~/utility/cache/cache.service';
+import { ProgramContent } from '~/program/entity/program_content.entity';
+import { ProgramContentLog } from '~/program/entity/ProgramContentLog';
+import { validate as uuidValidate } from 'uuid';
+
+@Injectable()
+export class PorterProgramService {
+  constructor(private readonly cacheService: CacheService) {}
+
+  async scanCacheForKeys(pattern: string, batchSize: number, cursor: string): Promise<[string, string[]]> {
+    const client = this.cacheService.getClient();
+    const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
+    return [scanResult[0], scanResult[1]];
+  }
+
+  async fetchValuesFromCache(keys: string[]): Promise<string[]> {
+    const client = this.cacheService.getClient();
+    return client.mget(keys);
+  }
+
+  parseKeyValuePairs(keys: string[], values: string[]): any[] {
+    return keys
+      .map((key, index) => {
+        const valueString = values[index];
+        if (!valueString) return null;
+
+        const [, memberId, , programContentId, createdAtString] = key.split(':');
+        return { key, memberId, programContentId, createdAtString, valueString };
+      })
+      .filter((item) => item !== null);
+  }
+
+  async fetchProgramContents(ids: string[], entityManager: EntityManager): Promise<Map<string, ProgramContent>> {
+    return this.findProgramContentsByIds(ids, entityManager);
+  }
+
+  createProgramContentLogs(keyValuePairs: any[], programContentsMap: Map<string, ProgramContent>): ProgramContentLog[] {
+    return keyValuePairs
+      .map(({ memberId, programContentId, createdAtString, valueString }) => {
+        const createdAtTimestamp = parseInt(createdAtString, 10);
+        const createdAtDate = new Date(createdAtTimestamp);
+        const value = JSON.parse(valueString);
+        const programContent = programContentsMap.get(programContentId);
+
+        if (!programContent) {
+          console.error(`Processing failed: Program content not found for ID ${programContentId}`);
+          return null;
+        }
+
+        const programContentLog = new ProgramContentLog();
+        programContentLog.memberId = memberId;
+        programContentLog.programContent = programContent;
+        programContentLog.playbackRate = value.playbackRate || 1;
+        programContentLog.startedAt = value.startedAt || 0;
+        programContentLog.endedAt = value.endedAt || 0;
+        programContentLog.createdAt = createdAtDate;
+
+        return programContentLog;
+      })
+      .filter((log) => log !== null);
+  }
+
+  async saveProgramContentLogs(programContentLogs: ProgramContentLog[], entityManager: EntityManager): Promise<void> {
+    await entityManager.save(ProgramContentLog, programContentLogs);
+  }
+
+  async deleteProcessedKeysFromCache(keys: string[]): Promise<void> {
+    const client = this.cacheService.getClient();
+    await client.del(...keys);
+  }
+
+  async handleBatchSaveFailure(
+    programContentLogs: ProgramContentLog[],
+    keys: string[],
+    manager: EntityManager,
+  ): Promise<void> {
+    for (let i = 0; i < programContentLogs.length; i++) {
+      try {
+        await this.saveProgramContentLogs([programContentLogs[i]], manager);
+      } catch (innerError) {
+        console.error(`Saving log failed: ${innerError}`);
+      }
+      await this.deleteProcessedKeysFromCache([keys[i]]);
+    }
+  }
+
+  public async findProgramContentsByIds(
+    ids: string[],
+    entityManager: EntityManager,
+  ): Promise<Map<string, ProgramContent>> {
+    const programContentRepo = entityManager.getRepository(ProgramContent);
+
+    const validIds = ids.filter((id) => uuidValidate(id));
+
+    if (validIds.length === 0) {
+      return new Map<string, ProgramContent>();
+    }
+
+    const programContents = await programContentRepo.findBy({ id: In(validIds) });
+    const programContentMap = new Map<string, ProgramContent>();
+    programContents.forEach((pc) => programContentMap.set(pc.id, pc));
+    return programContentMap;
+  }
+}

--- a/src/program/program.module.ts
+++ b/src/program/program.module.ts
@@ -9,10 +9,12 @@ import { MemberModule } from '~/member/member.module';
 import { DefinitionInfrastructure } from '~/definition/definition.infra';
 import { ProgramInfrastructure } from './program.infra';
 import { UtilityService } from '~/utility/utility.service';
+import { PorterProgramService } from './porter-program.service';
+import { UtilityModule } from '~/utility/utility.module';
 
 @Module({
   controllers: [ProgramController],
-  imports: [AuthModule, MemberModule],
+  imports: [AuthModule, MemberModule, UtilityModule],
   providers: [
     ProgramService,
     ProgramPlanService,
@@ -20,7 +22,8 @@ import { UtilityService } from '~/utility/utility.service';
     DefinitionInfrastructure,
     ProgramInfrastructure,
     UtilityService,
+    PorterProgramService,
   ],
-  exports: [ProgramService],
+  exports: [ProgramService, PorterProgramService, ProgramInfrastructure],
 })
 export class ProgramModule {}

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { ProgramContent } from './entity/program_content.entity';
@@ -7,6 +7,7 @@ import { MemberService } from '~/member/member.service';
 import { APIException } from '~/api.excetion';
 import { ProgramInfrastructure } from './program.infra';
 import { ProgramContentLog } from '~/program/entity/ProgramContentLog';
+import { validate as uuidValidate } from 'uuid';
 
 @Injectable()
 export class ProgramService {
@@ -104,17 +105,5 @@ export class ProgramService {
         (a: { createdAt: string }, b: { createdAt: string }) =>
           dayjs(a.createdAt).valueOf() - dayjs(b.createdAt).valueOf(),
       );
-  }
-
-  public async findProgramContentById(id: string, entityManager: EntityManager): Promise<ProgramContent | null> {
-    const programContentRepo = entityManager.getRepository(ProgramContent);
-    return programContentRepo.findOneBy({ id });
-  }
-
-  public async saveProgramContentLogs(
-    programContentLogs: ProgramContentLog[],
-    entityManager: EntityManager,
-  ): Promise<void> {
-    await entityManager.save(ProgramContentLog, programContentLogs);
   }
 }

--- a/src/runner/porter.runner.ts
+++ b/src/runner/porter.runner.ts
@@ -13,6 +13,8 @@ import { MemberService } from '~/member/member.service';
 import { ProgramService } from '~/program/program.service';
 import { PodcastService } from '~/podcast/podcast.service';
 import { PodcastProgressInfo } from '~/podcast/podcast.types';
+import { PorterProgramService } from '~/program/porter-program.service';
+import { ProgramInfrastructure } from '~/program/program.infra';
 
 @Injectable()
 export class PorterRunner extends Runner {
@@ -24,6 +26,8 @@ export class PorterRunner extends Runner {
     private readonly memberService: MemberService,
     private readonly programService: ProgramService,
     private readonly podcastService: PodcastService,
+    private readonly porterProgramService: PorterProgramService,
+    private readonly programInfra: ProgramInfrastructure,
 
     @InjectEntityManager() private readonly entityManager: EntityManager,
   ) {
@@ -59,92 +63,92 @@ export class PorterRunner extends Runner {
     }
   }
 
-  async portPlayerEvent(manager: EntityManager): Promise<void> {
+  async portPlayerEvent(manager: EntityManager, batchSize = 1000): Promise<void> {
     const pattern = 'program-content-event:*:program-content:*:*';
-    const allKeys = await this.cacheService.getClient().keys(pattern);
-    const batchSize = 30;
-    const programContentLogs: ProgramContentLog[] = [];
+    let cursor = '0';
 
-    for (let batchIndex = 0; batchIndex < allKeys.length; batchIndex += batchSize) {
-      const batchKeys = allKeys.slice(batchIndex, batchIndex + batchSize);
-      const values = await this.cacheService.getClient().mget(batchKeys);
+    do {
+      const [newCursor, keys] = await this.porterProgramService.scanCacheForKeys(pattern, batchSize, cursor);
+      cursor = newCursor;
 
-      for (let keyIndex = 0; keyIndex < batchKeys.length; keyIndex++) {
-        const key = batchKeys[keyIndex];
-        const valueString = values[keyIndex];
-        const [, memberId, , programContentId, createdAtString] = key.split(':');
-        const createdAtTimestamp = parseInt(createdAtString, 10);
-        const createdAtDate = new Date(createdAtTimestamp);
-        const value = JSON.parse(valueString || '{}');
+      if (keys.length > 0) {
+        const values = await this.porterProgramService.fetchValuesFromCache(keys);
+        const keyValuePairs = this.porterProgramService.parseKeyValuePairs(keys, values);
+        const programContentIds = new Set(keyValuePairs.map((kvp) => kvp.programContentId));
+        const programContentsMap = await this.porterProgramService.fetchProgramContents(
+          Array.from(programContentIds),
+          manager,
+        );
+        const programContentLogs = this.porterProgramService.createProgramContentLogs(
+          keyValuePairs,
+          programContentsMap,
+        );
 
-        try {
-          const programContent = await this.programService.findProgramContentById(programContentId, manager);
-
-          if (programContent) {
-            const programContentLog = new ProgramContentLog();
-            programContentLog.memberId = memberId;
-            programContentLog.programContent = programContent;
-            programContentLog.playbackRate = value.playbackRate || 1;
-            programContentLog.startedAt = value.startedAt || 0;
-            programContentLog.endedAt = value.endedAt || 0;
-            programContentLog.createdAt = createdAtDate;
-
-            programContentLogs.push(programContentLog);
+        if (programContentLogs.length > 0) {
+          try {
+            await this.programInfra.saveProgramContentLogs(programContentLogs, manager);
+            await this.porterProgramService.deleteProcessedKeysFromCache(keys);
+          } catch (error) {
+            await this.porterProgramService.handleBatchSaveFailure(programContentLogs, keys, manager);
           }
-        } catch (error) {
-          console.error(`Processing ${key} failed: ${error}`);
         }
       }
-    }
-
-    if (programContentLogs.length > 0) {
-      try {
-        await this.programService.saveProgramContentLogs(programContentLogs, manager);
-        await this.cacheService.getClient().del(...allKeys);
-      } catch (error) {
-        console.error(`Batch saving or deleting keys failed: ${error}`);
-      }
-    }
+    } while (cursor !== '0');
   }
 
-  async portPodcastProgram(manager: EntityManager): Promise<void> {
-    const errors: Array<{ error: any }> = [];
+  async portPodcastProgram(manager: EntityManager, batchSize = 1000): Promise<void> {
     const pattern = 'podcast-program-event:*:podcast-program:*:*';
-    const allKeys = await this.cacheService.getClient().keys(pattern);
+    const client = this.cacheService.getClient();
+    let cursor = '0';
 
-    const progressMap = new Map<string, PodcastProgressInfo>();
+    do {
+      const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+      const progressInfoList = [];
 
-    for (const key of allKeys) {
-      const valueString = await this.cacheService.getClient().get(key);
-      if (!valueString) continue;
+      for (const key of keys) {
+        const valueString = await client.get(key);
+        if (!valueString) continue;
 
-      const [, memberId, , podcastProgramId, createdAtString] = key.split(':');
-      const createdAtTimestamp = parseInt(createdAtString, 10);
-      const createdAtDate = new Date(createdAtTimestamp);
+        const [, memberId, , podcastProgramId, createdAtString] = key.split(':');
+        const createdAtTimestamp = parseInt(createdAtString, 10);
+        const createdAtDate = new Date(createdAtTimestamp);
 
-      const value = JSON.parse(valueString);
-      const progressInfo: PodcastProgressInfo = {
-        memberId,
-        podcastProgramId,
-        progress: value.progress,
-        lastProgress: value.progress,
-        podcastAlbumId: value.podcastAlbumId,
-        created_at: createdAtDate,
-      };
-      progressMap.set(memberId + '_' + podcastProgramId, progressInfo);
-    }
+        const value = JSON.parse(valueString);
+        progressInfoList.push({
+          key,
+          memberId,
+          podcastProgramId,
+          progress: value.progress,
+          lastProgress: value.lastProgress,
+          podcastAlbumId: value.podcastAlbumId,
+          created_at: createdAtDate,
+        });
+      }
 
-    try {
-      await this.podcastService.processPodcastProgramProgress(progressMap, manager);
-      await this.cacheService.getClient().del(...allKeys);
-    } catch (error) {
-      console.error('Error processing podcast program progress:', error);
-      errors.push({ error: error.message });
-    }
+      progressInfoList.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
 
-    if (errors.length > 0) {
-      throw new Error(JSON.stringify(errors));
-    }
+      if (progressInfoList.length > 0) {
+        try {
+          await this.podcastService.processPodcastProgramProgress(progressInfoList, manager);
+          await client.del(...progressInfoList.map((info) => info.key));
+        } catch (error) {
+          console.error('Batch saving failed:', error);
+          for (const progressInfo of progressInfoList) {
+            try {
+              await this.podcastService.processPodcastProgramProgress([progressInfo], manager);
+            } catch (innerError) {
+              console.error(
+                `Saving progress for ${progressInfo.key} , value ${JSON.stringify(progressInfo)} failed:`,
+                innerError,
+              );
+            }
+            await client.del(progressInfo.key);
+          }
+        }
+      }
+    } while (cursor !== '0');
   }
 
   async checkAndCallHeartbeat(): Promise<void> {

--- a/src/runner/porter.runner.ts
+++ b/src/runner/porter.runner.ts
@@ -120,9 +120,9 @@ export class PorterRunner extends Runner {
           key,
           memberId,
           podcastProgramId,
-          progress: value.progress,
-          lastProgress: value.lastProgress,
-          podcastAlbumId: value.podcastAlbumId,
+          progress: value?.progress,
+          lastProgress: value?.lastProgress,
+          podcastAlbumId: value?.podcastAlbumId,
           created_at: createdAtDate,
         });
       }

--- a/test/runner/porter_runner.e2e-spec.ts
+++ b/test/runner/porter_runner.e2e-spec.ts
@@ -373,6 +373,9 @@ describe('PorterRunner (e2e)', () => {
         expect(latesProgress.podcastProgramId).toEqual(podcastProgram.id);
         expect(latesProgress.progress).toEqual('190.2503679064795');
         expect(latesProgress.podcastAlbumId).toEqual(podcastAlbum.id);
+        const scanResult = await cacheService.getClient().keys('podcast-program-event:*:podcast-program:*:*');
+        const remainingKeysCount = scanResult.length;
+        expect(remainingKeysCount).toEqual(0);
       });
 
       it('when 3 record are same member and podcastProgram , should only have one record in db', async () => {
@@ -398,6 +401,10 @@ describe('PorterRunner (e2e)', () => {
 
         const record = progressRecords.find((record) => record.memberId === member.id);
         expect(record.progress).toEqual('13');
+
+        const scanResult = await cacheService.getClient().keys('podcast-program-event:*:podcast-program:*:*');
+        const remainingKeysCount = scanResult.length;
+        expect(remainingKeysCount).toEqual(0);
       });
 
       it('when batch size is 20, 80 records in Redis, 2 member podcast programs, 1 member has an error', async () => {
@@ -453,6 +460,10 @@ describe('PorterRunner (e2e)', () => {
         expect(record.lastProgress).not.toEqual(`${5 + 79}`);
         expect(insertedMemberRecord.lastProgress).toEqual(`${5 + 70}`);
         expect(consoleSpy).toHaveBeenCalled();
+
+        const scanResult = await cacheService.getClient().keys('podcast-program-event:*:podcast-program:*:*');
+        const remainingKeysCount = scanResult.length;
+        expect(remainingKeysCount).toEqual(0);
       });
     });
 
@@ -467,6 +478,10 @@ describe('PorterRunner (e2e)', () => {
 
         const progressRecords = await podcastProgramProgressRepo.find();
         expect(progressRecords.length).toEqual(0);
+
+        const scanResult = await cacheService.getClient().keys('podcast-program-event:*');
+        const remainingKeysCount = scanResult.length;
+        expect(remainingKeysCount).toEqual(0);
       });
 
       it('should process and save 2 out of 30 records, when one memberId does not exist', async () => {
@@ -525,6 +540,10 @@ describe('PorterRunner (e2e)', () => {
         const nonExistentRecord = progressRecords.find((record) => record.memberId === nonExistentMemberId);
         expect(nonExistentRecord).toBeUndefined();
         expect(consoleSpy).toHaveBeenCalled();
+
+        const scanResult = await cacheService.getClient().keys('podcast-program-event:*:podcast-program:*:*');
+        const remainingKeysCount = scanResult.length;
+        expect(remainingKeysCount).toEqual(0);
       });
     });
   });

--- a/test/runner/porter_runner.e2e-spec.ts
+++ b/test/runner/porter_runner.e2e-spec.ts
@@ -43,6 +43,7 @@ import { ProgramContentLog } from '~/program/entity/ProgramContentLog';
 import { PodcastProgramProgress } from '~/podcast/entity/PodcastProgramProgress';
 import { PodcastProgram } from '~/podcast/entity/PodcastProgram';
 import { PodcastAlbum } from '~/podcast/entity/PodcastAlbum';
+import { v4 } from 'uuid';
 
 jest.mock('axios', () => ({
   get: jest.fn(),
@@ -227,7 +228,7 @@ describe('PorterRunner (e2e)', () => {
     it('should correctly save program content log', async () => {
       const porterRunner = application.get<PorterRunner>(Runner);
 
-      await porterRunner.execute(manager);
+      await porterRunner.portPlayerEvent(manager, 30);
 
       const [latestLog] = await programContentLogRepo.find({
         order: { createdAt: 'DESC' },
@@ -239,23 +240,292 @@ describe('PorterRunner (e2e)', () => {
       expect(latestLog.endedAt).toEqual('502.26019');
       expect(latestLog.memberId).toEqual(member.id);
     });
+
+    describe('portPlayerEvent with batchSize 20', () => {
+      it('should correctly process and save all 80 records', async () => {
+        await programContentLogRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        for (let i = 0; i < 80; i++) {
+          await cacheService
+            .getClient()
+            .set(
+              `program-content-event:${member.id}:program-content:${programContent.id}:${Date.now() + i}`,
+              JSON.stringify({ playbackRate: 1.25, startedAt: 500 + i, endedAt: 600 + i }),
+              'EX',
+              7 * 86400,
+            );
+        }
+
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPlayerEvent(manager, 20);
+
+        const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
+        expect(logs.length).toEqual(80);
+        logs.forEach((log, index) => {
+          expect(log.playbackRate).toEqual('1.25');
+          expect(log.startedAt).toEqual(`${500 + index}`);
+          expect(log.endedAt).toEqual(`${600 + index}`);
+          expect(log.memberId).toEqual(member.id);
+        });
+      });
+      it('should process and save 79 out of 80 records and delete all Redis keys , when memberId did not exist', async () => {
+        await programContentLogRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        const nonExistentMemberId = 'non-existent-member-id';
+        for (let i = 0; i < 80; i++) {
+          const memberId = i === 50 ? nonExistentMemberId : member.id;
+          await cacheService
+            .getClient()
+            .set(
+              `program-content-event:${memberId}:program-content:${programContent.id}:${Date.now() + i}`,
+              JSON.stringify({ playbackRate: 1.25, startedAt: 500 + i, endedAt: 600 + i }),
+              'EX',
+              7 * 86400,
+            );
+        }
+        const consoleSpy = jest.spyOn(console, 'error');
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPlayerEvent(manager, 20);
+
+        const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
+        expect(logs.length).toEqual(79);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Saving log failed: QueryFailedError: insert or update on table "program_content_log" violates foreign key constraint "program_content_log_member_id_fkey"',
+          ),
+        );
+
+        logs.forEach((log, index) => {
+          expect(log.playbackRate).toEqual('1.25');
+          expect(log.startedAt).not.toEqual(`${500 + 50}`);
+          expect(log.endedAt).not.toEqual(`${600 + 50}`);
+          expect(log.memberId).not.toEqual(nonExistentMemberId);
+        });
+
+        const remainingKeys = await cacheService.getClient().keys('program-content-event:*');
+        console.log(remainingKeys);
+        expect(remainingKeys.length).toEqual(0);
+      });
+      it('should process and save 79 out of 80 records and delete all Redis keys, when startAt format error', async () => {
+        await programContentLogRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        for (let i = 0; i < 80; i++) {
+          const programContentId = i === 50 ? 'nonExistProgramContentId' : programContent.id; // Introduce error in one record
+          await cacheService
+            .getClient()
+            .set(
+              `program-content-event:${member.id}:program-content:${programContentId}:${Date.now() + i}`,
+              JSON.stringify({ playbackRate: 1.25, startedAt: 500 + i, endedAt: 600 + i }),
+              'EX',
+              7 * 86400,
+            );
+        }
+
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPlayerEvent(manager, 20);
+
+        const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
+        expect(logs.length).toEqual(79);
+
+        logs.forEach((log, index) => {
+          expect(log.playbackRate).toEqual('1.25');
+          expect(log.startedAt).not.toEqual(`${500 + 50}`);
+          expect(log.endedAt).not.toEqual(`${600 + 50}`);
+          expect(log.programContentId).not.toEqual('nonExistProgramContentId');
+        });
+
+        const remainingKeys = await cacheService.getClient().keys('program-content-event:*');
+        expect(remainingKeys.length).toEqual(0);
+      });
+    });
+
+    describe('portPlayerEvent with no Redis data', () => {
+      it('should not save any data and not throw errors', async () => {
+        await programContentLogRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        const porterRunner = application.get<PorterRunner>(Runner);
+
+        await expect(porterRunner.portPlayerEvent(manager)).resolves.not.toThrow();
+
+        const logs = await programContentLogRepo.find();
+        expect(logs.length).toEqual(0);
+      });
+    });
   });
 
   describe('portPodcastProgram', () => {
-    it('should correctly save podcast program progress', async () => {
-      const porterRunner = application.get<PorterRunner>(Runner);
+    describe('Success scenarios', () => {
+      it('should correctly save podcast program progress', async () => {
+        const porterRunner = application.get<PorterRunner>(Runner);
 
-      await porterRunner.execute(manager);
+        await porterRunner.execute(manager);
 
-      const [latesProgress] = await podcastProgramProgressRepo.find({
-        order: { createdAt: 'DESC' },
-        take: 1,
+        const [latesProgress] = await podcastProgramProgressRepo.find({
+          order: { createdAt: 'DESC' },
+          take: 1,
+        });
+
+        expect(latesProgress.memberId).toEqual(member.id);
+        expect(latesProgress.podcastProgramId).toEqual(podcastProgram.id);
+        expect(latesProgress.progress).toEqual('190.2503679064795');
+        expect(latesProgress.podcastAlbumId).toEqual(podcastAlbum.id);
       });
 
-      expect(latesProgress.memberId).toEqual(member.id);
-      expect(latesProgress.podcastProgramId).toEqual(podcastProgram.id);
-      expect(latesProgress.progress).toEqual('190.2503679064795');
-      expect(latesProgress.podcastAlbumId).toEqual(podcastAlbum.id);
+      it('when 3 record are same member and podcastProgram , should only have one record in db', async () => {
+        await podcastProgramProgressRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        for (let i = 0; i < 4; i++) {
+          await cacheService
+            .getClient()
+            .set(
+              `podcast-program-event:${member.id}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+              JSON.stringify({ progress: `${10.0 + i}`, lastProgress: `${5 + i}`, podcastAlbumId: podcastAlbum.id }),
+              'EX',
+              7 * 86400,
+            );
+        }
+
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPodcastProgram(manager);
+
+        const progressRecords = await podcastProgramProgressRepo.find();
+        expect(progressRecords.length).toEqual(1);
+
+        const record = progressRecords.find((record) => record.memberId === member.id);
+        expect(record.progress).toEqual('13');
+      });
+
+      it('when batch size is 20, 80 records in Redis, 2 member podcast programs, 1 member has an error', async () => {
+        await podcastProgramProgressRepo.delete({});
+        await cacheService.getClient().flushall();
+        const nonExistentMemberId = 'nonExistMemberId';
+
+        const insertedMemberId = v4();
+        const insertedMember = new Member();
+        insertedMember.appId = app.id;
+        insertedMember.id = insertedMemberId;
+        insertedMember.name = `name`;
+        insertedMember.username = `username`;
+        insertedMember.email = `email@example.com`;
+        insertedMember.role = 'general-member';
+        insertedMember.star = 0;
+        insertedMember.createdAt = new Date();
+        insertedMember.loginedAt = new Date();
+        await manager.save(insertedMember);
+
+        for (let i = 0; i < 80; i++) {
+          const currentMemberId = i === 79 ? nonExistentMemberId : member.id;
+          await cacheService
+            .getClient()
+            .set(
+              `podcast-program-event:${currentMemberId}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+              JSON.stringify({ progress: `${10.0 + i}`, lastProgress: `${5 + i}`, podcastAlbumId: podcastAlbum.id }),
+              'EX',
+              7 * 86400,
+            );
+
+          if (i % 10 === 0) {
+            await cacheService
+              .getClient()
+              .set(
+                `podcast-program-event:${insertedMemberId}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+                JSON.stringify({ progress: `${10.0 + i}`, lastProgress: `${5 + i}`, podcastAlbumId: podcastAlbum.id }),
+                'EX',
+                7 * 86400,
+              );
+          }
+        }
+        const consoleSpy = jest.spyOn(console, 'error');
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPodcastProgram(manager);
+
+        const progressRecords = await podcastProgramProgressRepo.find();
+        expect(progressRecords.length).toEqual(2);
+
+        const record = progressRecords.find((record) => record.memberId === member.id);
+        const insertedMemberRecord = progressRecords.find((record) => record.memberId === insertedMemberId);
+        expect(record.progress).toEqual(`${10 + 78}`);
+        expect(record.lastProgress).not.toEqual(`${5 + 79}`);
+        expect(insertedMemberRecord.lastProgress).toEqual(`${5 + 70}`);
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('Failure scenarios', () => {
+      it('should not save any data and not throw errors', async () => {
+        await podcastProgramProgressRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        const porterRunner = application.get<PorterRunner>(Runner);
+
+        await expect(porterRunner.portPodcastProgram(manager)).resolves.not.toThrow();
+
+        const progressRecords = await podcastProgramProgressRepo.find();
+        expect(progressRecords.length).toEqual(0);
+      });
+
+      it('should process and save 2 out of 30 records, when one memberId does not exist', async () => {
+        await podcastProgramProgressRepo.delete({});
+        await cacheService.getClient().flushall();
+
+        const memberId = v4();
+        const insertedMember = new Member();
+        insertedMember.appId = app.id;
+        insertedMember.id = memberId;
+        insertedMember.name = `name`;
+        insertedMember.username = `username`;
+        insertedMember.email = `delete@example.com`;
+        insertedMember.role = 'general-member';
+        insertedMember.star = 0;
+        insertedMember.createdAt = new Date();
+        insertedMember.loginedAt = new Date();
+        await manager.save(insertedMember);
+
+        const nonExistentMemberId = 'non-existent-member-id';
+
+        await cacheService
+          .getClient()
+          .set(
+            `podcast-program-event:${member.id}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+            JSON.stringify({ progress: '10.0', lastProgress: '5.0', podcastAlbumId: podcastAlbum.id }),
+            'EX',
+            7 * 86400,
+          );
+
+        await cacheService
+          .getClient()
+          .set(
+            `podcast-program-event:${insertedMember.id}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+            JSON.stringify({ progress: '10.0', lastProgress: '5.0', podcastAlbumId: podcastAlbum.id }),
+            'EX',
+            7 * 86400,
+          );
+
+        await cacheService
+          .getClient()
+          .set(
+            `podcast-program-event:${nonExistentMemberId}:podcast-program:${podcastProgram.id}:${Date.now()}`,
+            JSON.stringify({ progress: '10.0', lastProgress: '5.0', podcastAlbumId: podcastAlbum.id }),
+            'EX',
+            7 * 86400,
+          );
+
+        const consoleSpy = jest.spyOn(console, 'error');
+        const porterRunner = application.get<PorterRunner>(Runner);
+        await porterRunner.portPodcastProgram(manager);
+
+        const progressRecords = await podcastProgramProgressRepo.find();
+        expect(progressRecords.length).toEqual(2);
+
+        const nonExistentRecord = progressRecords.find((record) => record.memberId === nonExistentMemberId);
+        expect(nonExistentRecord).toBeUndefined();
+        expect(consoleSpy).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/test/runner/porter_runner.e2e-spec.ts
+++ b/test/runner/porter_runner.e2e-spec.ts
@@ -242,7 +242,7 @@ describe('PorterRunner (e2e)', () => {
     });
 
     describe('portPlayerEvent with batchSize 20', () => {
-      it('should correctly process and save all 80 records', async () => {
+      it('Assess the handling and accurate processing of 80 program content log records in batches', async () => {
         await programContentLogRepo.delete({});
         await cacheService.getClient().flushall();
 
@@ -343,7 +343,7 @@ describe('PorterRunner (e2e)', () => {
     });
 
     describe('portPlayerEvent with no Redis data', () => {
-      it('should not save any data and not throw errors', async () => {
+      it('Ensure proper handling and no errors when no Redis data is available for processing player events', async () => {
         await programContentLogRepo.delete({});
         await cacheService.getClient().flushall();
 
@@ -359,7 +359,7 @@ describe('PorterRunner (e2e)', () => {
 
   describe('portPodcastProgram', () => {
     describe('Success scenarios', () => {
-      it('should correctly save podcast program progress', async () => {
+      it('Check if podcast program progress is correctly saved and processed.', async () => {
         const porterRunner = application.get<PorterRunner>(Runner);
 
         await porterRunner.execute(manager);
@@ -378,7 +378,7 @@ describe('PorterRunner (e2e)', () => {
         expect(remainingKeysCount).toEqual(0);
       });
 
-      it('when 3 record are same member and podcastProgram , should only have one record in db', async () => {
+      it('Verify deduplication, ensuring only one record is saved in the database for duplicate entries , and should save the last create record', async () => {
         await podcastProgramProgressRepo.delete({});
         await cacheService.getClient().flushall();
 
@@ -468,7 +468,7 @@ describe('PorterRunner (e2e)', () => {
     });
 
     describe('Failure scenarios', () => {
-      it('should not save any data and not throw errors', async () => {
+      it('when redis is empty , should not save any data and not throw errors', async () => {
         await podcastProgramProgressRepo.delete({});
         await cacheService.getClient().flushall();
 
@@ -484,7 +484,7 @@ describe('PorterRunner (e2e)', () => {
         expect(remainingKeysCount).toEqual(0);
       });
 
-      it('should process and save 2 out of 30 records, when one memberId does not exist', async () => {
+      it('Evaluate error handling when processing podcast progress records with a non-existent member ID', async () => {
         await podcastProgramProgressRepo.delete({});
         await cacheService.getClient().flushall();
 


### PR DESCRIPTION
## 描述
目前porter runner 已部署至測試站
但有幾個問題需要改進

### 遇到的問題 - `redis`
redis 的 `keys` function , 會造成事務堵塞, 當keys鍵多時，有機會再porter runner 運行週期結束時還停在取keys，導致只取keys而來不及做其他處理程序就被kill

#### 解決方式 - 使用 `scan`
```
let cursor = '0';
do {
  const [newCursor, keys] = await this.porterProgramService.scanCacheForKeys(pattern, batchSize, cursor);
  cursor = newCursor;
    }
  } while (cursor !== '0');
```

### 遇到的問題 - `save`
typeorm 的 `save` 方法的運作原理如下
  - 若成功save，回傳entity
  - 若失敗則rollback並且throw error 
     - 會造成那一批次若儲存失敗，就不會被儲存，而是直接被跳出，就算裡面有可以順利儲存的資料也一樣
 #### 解決方式 - 失敗時跑迴圈
```
      if (progressInfoList.length > 0) {
        try {
          await this.podcastService.processPodcastProgramProgress(progressInfoList, manager); // 這裡失敗
          await client.del(...progressInfoList.map((info) => info.key)); // 若上面save失敗的話，這邊就不會del，上面會直貼跳出，並被 catch抓到
        } catch (error) {
          console.error('Batch saving failed:', error);
          for (const progressInfo of progressInfoList) { // 失敗的list 重新跑迴圈 , 一個個儲存
            try {
              await this.podcastService.processPodcastProgramProgress([progressInfo], manager);
            } catch (innerError) {
              console.error(
                `Saving progress for ${progressInfo.key} , value ${JSON.stringify(progressInfo)} failed:`,
                innerError,
              );
            }
            await client.del(progressInfo.key); // 統一刪掉keys , 失敗的也要刪掉
          }
        }
      }
```

### 額外重構的部分
1. 由於 `portPlayerEvent` 處理邏輯太多，故將之拆解成小邏輯，並新增一個 `PorterProgramService`
2. 讓 `batchSize` 變成function的輸入參數，這樣可以在測試做到小規模測試

## Test Scenarios

### Heartbeat Testing
- **Objective:** To verify the heartbeat URL call when `PORTER_HEARTBEAT_URL` is set.
- **Method:** `porterRunner.execute(manager)` is called and Axios's `get` method is checked for invocation with the test URL.

### Last Logged-In Member Update
- **Objective:** To test updating of the `loginedAt` field for members after executing `porterRunner`.
- **Success Scenarios:**
  - **Single Member Update:** Set a member's last-logged-in time in Redis and verify if the member's `loginedAt` is updated. 
  - **Bulk Update (50 Members):** Create multiple members, set their last-logged-in times, and verify updates. 
  - **Last Login Time Accuracy:** Test for correct `loginedAt` update when a member has multiple login records. 
  - **Redis Key Clearance:** Verify that Redis keys are cleared after the member login date update. 
- **Failure Scenarios:**
  - **Non-Existent Member Handling:** Ensure Redis key is cleared even when the member does not exist, and a specific console error is logged. 
  - **Invalid Date Format Handling:** Test the system's behavior when the `last-logged-in` value cannot be converted to a date. The member's `loginedAt` should not be updated in this case. 

### Player Event Porting
- **Objective:** To validate the correct porting of player events.
- **Scenarios:**
  - **Single Record Processing:** Verify correct saving of a single program content log.
  - **Batch Processing (80 Records):** Test the handling and accuracy of processing 80 program content log records in batches.
  - **Error Handling:** Assess scenarios like non-existent member ID and startAt format errors.
  - **No Redis Data:** Ensure proper handling when no Redis data is available.

### Podcast Program Porting
- **Objective:** To check if podcast program progress is correctly saved and processed.
- **Scenarios:**
  - **Success Cases:**
    - Verify processing of podcast progress data, including deduplication and last record preference.
    - Handle cases with different members, including one with an error.
  - **Failure Cases:**
    - Assess the scenario when Redis is empty.
    - Evaluate error handling for processing podcast progress records with a non-existent member ID.
