### PR TITLE
Feature/sale member lead data api

### DIFF
--- a/src/definition/entity/property.entity.ts
+++ b/src/definition/entity/property.entity.ts
@@ -41,6 +41,9 @@ export class Property {
   @Column('boolean', { name: 'is_business', default: () => false })
   isBusiness: boolean;
 
+  @Column('text', { name: 'app_id', unique: true })
+  appId: string;
+
   @OneToMany(() => MemberProperty, (memberProperty) => memberProperty.property)
   memberProperties: MemberProperty[];
 

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -10,8 +10,6 @@ import {
   UseGuards,
   Delete,
   Param,
-  HttpStatus,
-  HttpException,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { ConfigService } from '@nestjs/config';
@@ -187,11 +185,10 @@ export class MemberController {
     }
 
     if (errors.length > 0) {
-      throw new BadRequestException({
-        message: 'Invalid request parameters',
-        errors: errors,
-        statusCode: HttpStatus.BAD_REQUEST,
-      });
+      throw new APIException(
+        { code: 'SaleLeadMemberData_Error', message: 'Invalid request parameters', result: errors },
+        400,
+      );
     }
 
     try {
@@ -199,7 +196,10 @@ export class MemberController {
     } catch (error) {
       console.error('Error fetching sale lead member data:', error);
 
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new APIException(
+        { code: 'SaleLeadMemberData_Error', message: 'Error fetching sale lead member data', result: error },
+        500,
+      );
     }
   }
 

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -27,6 +27,8 @@ import {
   MemberGetDTO,
   MemberGetResultDTO,
   MemberImportDTO,
+  SaleLeadMemberDataResponseDTO,
+  SaleLeadMemberDataResquestDTO,
 } from './member.dto';
 import { MemberService } from './member.service';
 import { APIException } from '~/api.excetion';
@@ -171,6 +173,17 @@ export class MemberController {
       exportMime,
     };
     await this.exportQueue.add(exportJob, { removeOnComplete: true, removeOnFail: true });
+  }
+
+  @Post('saleLeadMemberData')
+  public async getSaleLeadMemberData(
+    @Body() requestDto: SaleLeadMemberDataResquestDTO,
+  ): Promise<SaleLeadMemberDataResponseDTO> {
+    return this.memberService.getSaleLeadMemberData(
+      requestDto.memberIds,
+      requestDto.categoryIds,
+      requestDto.propertyIds,
+    );
   }
 
   @Delete('email/:email')

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -179,11 +179,7 @@ export class MemberController {
   public async getSaleLeadMemberData(
     @Body() requestDto: SaleLeadMemberDataResquestDTO,
   ): Promise<SaleLeadMemberDataResponseDTO> {
-    return this.memberService.getSaleLeadMemberData(
-      requestDto.memberIds,
-      requestDto.categoryIds,
-      requestDto.propertyIds,
-    );
+    return this.memberService.getSaleLeadMemberData(requestDto.memberIds, requestDto.appId);
   }
 
   @Delete('email/:email')

--- a/src/member/member.dto.ts
+++ b/src/member/member.dto.ts
@@ -200,7 +200,7 @@ export class MemberGeneralLoginDTO {
 
 export class ActiveMemberContractDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsDate()
   agreed_at: Date;
@@ -214,7 +214,7 @@ export class ActiveMemberContractDTO {
 
 export class MemberTaskDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsString()
   status: string;
@@ -222,18 +222,21 @@ export class MemberTaskDTO {
 
 export class MemberPropertyDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsString()
-  property_id: string;
+  propertyId: string;
 
   @ValidateNested()
   value: any;
+
+  @IsString()
+  name: string;
 }
 
 export class MemberPhoneDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsString()
   phone: string;
@@ -241,7 +244,7 @@ export class MemberPhoneDTO {
 
 export class MemberNoteDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsString()
   description: string;
@@ -249,10 +252,10 @@ export class MemberNoteDTO {
 
 export class MemberCategoryDTO {
   @IsString()
-  member_id: string;
+  memberId: string;
 
   @IsString()
-  category_id: string;
+  categoryId: string;
 }
 
 export class SaleLeadMemberDataResponseDTO {
@@ -294,9 +297,6 @@ export class SaleLeadMemberDataResquestDTO {
   @IsArray()
   memberIds: Array<string>;
 
-  @IsArray()
-  propertyIds: Array<string>;
-
-  @IsArray()
-  categoryIds: Array<string>;
+  @IsString()
+  appId: string;
 }

--- a/src/member/member.dto.ts
+++ b/src/member/member.dto.ts
@@ -1,9 +1,21 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsEmail, IsEnum, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDate,
+  IsEmail,
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { DeleteResult } from 'typeorm';
 import { Cursor } from 'typeorm-cursor-pagination';
 
 import { MemberRole } from './member.type';
+import { isArray } from 'lodash';
 
 class FileInfo {
   @IsString()
@@ -184,4 +196,107 @@ export class MemberGeneralLoginDTO {
 
   @IsBoolean()
   isBusiness: boolean;
+}
+
+export class ActiveMemberContractDTO {
+  @IsString()
+  member_id: string;
+
+  @IsDate()
+  agreed_at: Date;
+
+  @IsDate()
+  revoked_at: Date;
+
+  @ValidateNested()
+  values: any;
+}
+
+export class MemberTaskDTO {
+  @IsString()
+  member_id: string;
+
+  @IsString()
+  status: string;
+}
+
+export class MemberPropertyDTO {
+  @IsString()
+  member_id: string;
+
+  @IsString()
+  property_id: string;
+
+  @ValidateNested()
+  value: any;
+}
+
+export class MemberPhoneDTO {
+  @IsString()
+  member_id: string;
+
+  @IsString()
+  phone: string;
+}
+
+export class MemberNoteDTO {
+  @IsString()
+  member_id: string;
+
+  @IsString()
+  description: string;
+}
+
+export class MemberCategoryDTO {
+  @IsString()
+  member_id: string;
+
+  @IsString()
+  category_id: string;
+}
+
+export class SaleLeadMemberDataResponseDTO {
+  @IsString()
+  member_id: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ActiveMemberContractDTO)
+  activeMemberContract: ActiveMemberContractDTO[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MemberTaskDTO)
+  memberTask: MemberTaskDTO[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MemberPropertyDTO)
+  memberProperty: MemberPropertyDTO[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MemberPhoneDTO)
+  memberPhone: MemberPhoneDTO[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MemberNoteDTO)
+  memberNote: MemberNoteDTO[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MemberCategoryDTO)
+  memberCategory: MemberCategoryDTO[];
+}
+
+export class SaleLeadMemberDataResquestDTO {
+  @IsArray()
+  memberIds: Array<string>;
+
+  @IsArray()
+  propertyIds: Array<string>;
+
+  @IsArray()
+  categoryIds: Array<string>;
 }

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -255,6 +255,12 @@ export class MemberInfrastructure {
       order: { position: 'asc' },
     });
 
+    const categoryIds = categories.map((c) => c.id);
+
+    if (categoryIds.length === 0) {
+      return [];
+    }
+
     const categoriesMap = new Map(categories.map((cat) => [cat.id, cat]));
 
     const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
@@ -266,7 +272,7 @@ export class MemberInfrastructure {
     const query = memberCategoryRepo
       .createQueryBuilder('mc')
       .innerJoin(`(${valuesSubQuery})`, 'vals', 'mc.member_id = vals.member_id')
-      .andWhere('mc.category_id IN (:...categoryIds)', { categoryIds: categories.map((c) => c.id) });
+      .andWhere('mc.category_id IN (:...categoryIds)', { categoryIds });
 
     const memberCategories = await query.getMany();
 
@@ -310,6 +316,11 @@ export class MemberInfrastructure {
       order: { position: 'ASC' },
     });
     const propertyIds = properties.map((v) => v.id);
+
+    if (propertyIds.length === 0) {
+      return [];
+    }
+
     const propertyMap = new Map(properties.map((p) => [p.id, p]));
 
     const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
@@ -321,7 +332,7 @@ export class MemberInfrastructure {
     const query = memberPropertyRepo
       .createQueryBuilder('mp')
       .innerJoin(`(${valuesSubQuery})`, 'vals', 'mp.member_id = vals.member_id')
-      .andWhere('mp.property_id IN (:...propertyIds)', { propertyIds: properties.map((c) => c.id) });
+      .andWhere('mp.property_id IN (:...propertyIds)', { propertyIds });
 
     const memberProperties = await query.getMany();
 

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -187,6 +187,97 @@ export class MemberInfrastructure {
     return tasks;
   }
 
+  async getMemberTasksWithBulkIds(memberIds: string[], manager: EntityManager): Promise<MemberTask[]> {
+    const memberTaskRepo = manager.getRepository(MemberTask);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+    console.log('valuesSubQuery', valuesSubQuery);
+
+    const query = memberTaskRepo
+      .createQueryBuilder('mt')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id');
+
+    return await query.getMany();
+  }
+
+  async getMemberPhonesWithBulkIds(memberIds: string[], manager: EntityManager): Promise<MemberPhone[]> {
+    const memberPhoneRepo = manager.getRepository(MemberPhone);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+    console.log('valuesSubQuery', valuesSubQuery);
+
+    const query = memberPhoneRepo
+      .createQueryBuilder('mt')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id');
+
+    return await query.getMany();
+  }
+
+  async getMemberNotesWithBulkIds(memberIds: string[], manager: EntityManager): Promise<MemberNote[]> {
+    const memberNoteRepo = manager.getRepository(MemberNote);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+    console.log('valuesSubQuery', valuesSubQuery);
+
+    const query = memberNoteRepo
+      .createQueryBuilder('mt')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id');
+
+    return await query.getMany();
+  }
+
+  async getMemberCategoryWithBulkIds(
+    memberIds: string[],
+    categoryIds: string[],
+    manager: EntityManager,
+  ): Promise<MemberCategory[]> {
+    const memberCategoryRepo = manager.getRepository(MemberCategory);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+    console.log('valuesSubQuery', valuesSubQuery);
+
+    const query = memberCategoryRepo
+      .createQueryBuilder('mt')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id')
+      .andWhere('mc.category_id IN (:...categoryIds)', { categoryIds });
+
+    return await query.getMany();
+  }
+
+  async getMemberContractWithBulkIds(memberIds: string[], manager: EntityManager): Promise<MemberContract[]> {
+    const memberContractRepo = manager.getRepository(MemberContract);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+    console.log('valuesSubQuery', valuesSubQuery);
+
+    const query = memberContractRepo
+      .createQueryBuilder('mt')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id')
+      .andWhere('mc.agreed_at IS NOT NULL');
+
+    return await query.getMany();
+  }
+
   async getLoginMemberMetadata(memberId: string, manager: EntityManager): Promise<Array<LoginMemberMetadata>> {
     const builder = manager
       .createQueryBuilder()

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -52,6 +52,7 @@ import { Practice } from '~/entity/Practice';
 import { ProgramTimetable } from '~/entity/ProgramTimetable';
 import { Attend } from '~/entity/Attend';
 import { ReviewReply } from '~/entity/ReviewReply';
+import { Property } from '~/definition/entity/property.entity';
 
 @Injectable()
 export class MemberInfrastructure {
@@ -195,7 +196,6 @@ export class MemberInfrastructure {
       return [];
     }
     const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
-    console.log('valuesSubQuery', valuesSubQuery);
 
     const query = memberTaskRepo
       .createQueryBuilder('mt')
@@ -212,11 +212,10 @@ export class MemberInfrastructure {
       return [];
     }
     const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
-    console.log('valuesSubQuery', valuesSubQuery);
 
     const query = memberPhoneRepo
-      .createQueryBuilder('mt')
-      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id');
+      .createQueryBuilder('mp')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mp.member_id = vals.member_id');
 
     return await query.getMany();
   }
@@ -229,7 +228,6 @@ export class MemberInfrastructure {
       return [];
     }
     const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
-    console.log('valuesSubQuery', valuesSubQuery);
 
     const query = memberNoteRepo
       .createQueryBuilder('mt')
@@ -250,11 +248,10 @@ export class MemberInfrastructure {
       return [];
     }
     const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
-    console.log('valuesSubQuery', valuesSubQuery);
 
     const query = memberCategoryRepo
-      .createQueryBuilder('mt')
-      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id')
+      .createQueryBuilder('mc')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mc.member_id = vals.member_id')
       .andWhere('mc.category_id IN (:...categoryIds)', { categoryIds });
 
     return await query.getMany();
@@ -268,12 +265,32 @@ export class MemberInfrastructure {
       return [];
     }
     const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
-    console.log('valuesSubQuery', valuesSubQuery);
 
     const query = memberContractRepo
-      .createQueryBuilder('mt')
-      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mt.member_id = vals.member_id')
+      .createQueryBuilder('mc')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mc.member_id = vals.member_id')
       .andWhere('mc.agreed_at IS NOT NULL');
+
+    return await query.getMany();
+  }
+
+  async getMemberPropertiyWithBulkIds(
+    memberIds: string[],
+    propertyIds: string[],
+    manager: EntityManager,
+  ): Promise<MemberProperty[]> {
+    const memberPropertyRepo = manager.getRepository(MemberProperty);
+
+    const valuesList = memberIds.map((id) => `('${id}')`).join(', ');
+    if (valuesList.length < 1) {
+      return [];
+    }
+    const valuesSubQuery = `SELECT * FROM (VALUES ${valuesList}) AS vals(member_id)`;
+
+    const query = memberPropertyRepo
+      .createQueryBuilder('mp')
+      .innerJoin(`(${valuesSubQuery})`, 'vals', 'mp.member_id = vals.member_id')
+      .andWhere('mp.property_id IN (:...propertyIds)', { propertyIds });
 
     return await query.getMany();
   }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -356,7 +356,7 @@ export class MemberService {
   async getSaleLeadMemberData(memberIds, categoryIds, propertyIds): Promise<SaleLeadMemberDataResponseDTO> {
     const [memberProperties, memberTasks, memberPhones, memberNotes, memberCategories, memberContracts] =
       await Promise.all([
-        this.memberInfra.getMemberPropertiesByIds(memberIds, propertyIds, this.entityManager),
+        this.memberInfra.getMemberPropertiyWithBulkIds(memberIds, propertyIds, this.entityManager),
         this.memberInfra.getMemberTasksWithBulkIds(memberIds, this.entityManager),
         this.memberInfra.getMemberPhonesWithBulkIds(memberIds, this.entityManager),
         this.memberInfra.getMemberNotesWithBulkIds(memberIds, this.entityManager),

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -373,8 +373,6 @@ export class MemberService {
     responseDto.memberCategory = memberCategories.map(this.mapMemberCategory);
     responseDto.activeMemberContract = memberContracts.map(this.mapMemberContract);
 
-    console.log('esponseDt', responseDto);
-
     return responseDto;
   }
 

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -29,6 +29,7 @@ import { MemberProperty } from './entity/member_property.entity';
 import { MemberPhone } from './entity/member_phone.entity';
 import { MemberTag } from './entity/member_tag.entity';
 import { APIException } from '~/api.excetion';
+import { category } from 'test/data';
 
 @Injectable()
 export class MemberService {
@@ -353,14 +354,14 @@ export class MemberService {
     return this.memberInfra.getMemberTasks(memberId, this.entityManager);
   }
 
-  async getSaleLeadMemberData(memberIds, categoryIds, propertyIds): Promise<SaleLeadMemberDataResponseDTO> {
+  async getSaleLeadMemberData(memberIds, appId): Promise<SaleLeadMemberDataResponseDTO> {
     const [memberProperties, memberTasks, memberPhones, memberNotes, memberCategories, memberContracts] =
       await Promise.all([
-        this.memberInfra.getMemberPropertiyWithBulkIds(memberIds, propertyIds, this.entityManager),
+        this.memberInfra.getMemberPropertiyWithBulkIds(memberIds, appId, this.entityManager),
         this.memberInfra.getMemberTasksWithBulkIds(memberIds, this.entityManager),
         this.memberInfra.getMemberPhonesWithBulkIds(memberIds, this.entityManager),
         this.memberInfra.getMemberNotesWithBulkIds(memberIds, this.entityManager),
-        this.memberInfra.getMemberCategoryWithBulkIds(memberIds, categoryIds, this.entityManager),
+        this.memberInfra.getMemberCategoryWithBulkIds(memberIds, appId, this.entityManager),
         this.memberInfra.getMemberContractWithBulkIds(memberIds, this.entityManager),
       ]);
 
@@ -377,27 +378,36 @@ export class MemberService {
     return responseDto;
   }
 
-  private mapMemberProperty({ memberId, propertyId, value }) {
-    return { member_id: memberId, property_id: propertyId, value };
+  private mapMemberProperty({ memberProperty, property }) {
+    return {
+      memberId: memberProperty.memberId,
+      propertyId: property.id,
+      value: memberProperty.value,
+      name: property.name,
+    };
   }
 
   private mapMemberTask({ memberId, status }) {
-    return { member_id: memberId, status };
+    return { memberId: memberId, status };
   }
 
   private mapMemberPhone({ memberId, phone }) {
-    return { member_id: memberId, phone };
+    return { memberId: memberId, phone };
   }
 
   private mapMemberNote({ memberId, description }) {
-    return { member_id: memberId, description };
+    return { memberId: memberId, description };
   }
 
-  private mapMemberCategory({ memberId, categoryId }) {
-    return { member_id: memberId, category_id: categoryId };
+  private mapMemberCategory({ memberCategory, category }) {
+    return {
+      memberId: memberCategory.memberId,
+      name: category ? category.name : null,
+      categoryId: memberCategory.categoryId,
+    };
   }
 
   private mapMemberContract({ memberId, agreedAt, revokedAt, values }) {
-    return { member_id: memberId, agreed_at: agreedAt, revoked_at: revokedAt, values };
+    return { memberId: memberId, agreed_at: agreedAt, revoked_at: revokedAt, values };
   }
 }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -356,11 +356,15 @@ export class MemberService {
   }
 
   async timedMemberInfraFunction(name, memberInfraFunction, appId) {
-    const formattedTime = dayjs().format('YYYY-MM-DD HH:mm:ss.SSS');
-    const label = `${appId} - ${name} - ${formattedTime}`;
-    console.time(label);
+    const formattedTimestamp = dayjs().format('YYYY-MM-DD HH:mm:ss.SSS');
+    const start = performance.now();
+
     const result = await memberInfraFunction();
-    console.timeEnd(label);
+  
+    const end = performance.now();
+    const executionTime = end - start;
+    console.log(`Execution Log - App ID: ${appId} | Function: ${name} | Timestamp: ${formattedTimestamp} | Execution Time: ${executionTime.toFixed(3)} ms`);
+
     return result;
   }
 

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -2650,7 +2650,8 @@ describe('MemberController (e2e)', () => {
           .expect(400);
 
         expect(res.body.message).toEqual('Invalid request parameters');
-        expect(res.body.errors).toEqual(['appId must be a string and cannot be empty']);
+
+        expect(res.body.result).toEqual(['appId must be a string and cannot be empty']);
       });
     });
   });

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -2384,10 +2384,17 @@ describe('MemberController (e2e)', () => {
           const insertedMemberNote = new MemberNote();
           insertedMemberNote.memberId = memberId;
           insertedMemberNote.authorId = memberId;
-          insertedMemberNote.type = 'outbound';
+          insertedMemberNote.type = null;
           insertedMemberNote.status = 'missed';
           await manager.save(insertedMemberNote);
         });
+
+        const insertedMemberNote = new MemberNote();
+        insertedMemberNote.memberId = memberIds[0];
+        insertedMemberNote.authorId = memberIds[0];
+        insertedMemberNote.type = 'not null value';
+        insertedMemberNote.status = 'missed';
+        await manager.save(insertedMemberNote);
 
         const insertedContract = new Contract();
         insertedContract.appId = app.id;

--- a/test/member/controller.e2e-spec.ts
+++ b/test/member/controller.e2e-spec.ts
@@ -2313,4 +2313,338 @@ describe('MemberController (e2e)', () => {
       expect(res.body).toHaveProperty('message');
     });
   });
+  describe('members/saleLeadMemberData', () => {
+    const route = '/members/saleLeadMemberData';
+    describe('Success scenarios', () => {
+      it('should return data successfully for a valid request', async () => {
+        const memberIds = [];
+        for (let i = 0; i < 5; i++) {
+          const insertedMember = new Member();
+          insertedMember.appId = app.id;
+          insertedMember.id = v4();
+          insertedMember.name = `name${i}`;
+          insertedMember.username = `username${i}`;
+          insertedMember.email = `email${i}@example.com`;
+          insertedMember.role = 'general-member';
+          insertedMember.star = 0;
+          insertedMember.createdAt = new Date();
+          insertedMember.loginedAt = new Date();
+          await manager.save(insertedMember);
+          memberIds.push(insertedMember.id);
+        }
+
+        const insertedProperty = new Property();
+        insertedProperty.appId = app.id;
+        insertedProperty.name = 'aaaa';
+        insertedProperty.position = 1;
+        insertedProperty.type = 'member';
+        await manager.save(insertedProperty);
+
+        const insertedCategory = new Category();
+        insertedCategory.appId = app.id;
+        insertedCategory.name = 'bbbb';
+        insertedCategory.class = 'member';
+        insertedCategory.position = 1;
+        await manager.save(insertedCategory);
+
+        memberIds.map(async (memberId) => {
+          const insertedMemberCategory = new MemberCategory();
+          insertedMemberCategory.category = insertedCategory;
+          insertedMemberCategory.memberId = memberId;
+          insertedMemberCategory.position = 1;
+          await manager.save(insertedMemberCategory);
+        });
+
+        memberIds.map(async (memberId) => {
+          const insertedMemberProperty = new MemberProperty();
+          insertedMemberProperty.property = insertedProperty;
+          insertedMemberProperty.memberId = memberId;
+          insertedMemberProperty.value = 'ccccc';
+          await manager.save(insertedMemberProperty);
+        });
+
+        memberIds.map(async (memberId) => {
+          const insertedMemberTask = new MemberTask();
+          insertedMemberTask.memberId = memberId;
+          insertedMemberTask.title = 'title';
+          insertedMemberTask.priority = 'high';
+          insertedMemberTask.status = 'done';
+          await manager.save(insertedMemberTask);
+        });
+
+        memberIds.map(async (memberId, index) => {
+          const insertedMemberPhone = new MemberPhone();
+          insertedMemberPhone.id = v4();
+          insertedMemberPhone.memberId = memberId;
+          insertedMemberPhone.phone = `0900000000${index}`;
+          await manager.save(insertedMemberPhone);
+        });
+
+        memberIds.map(async (memberId) => {
+          const insertedMemberNote = new MemberNote();
+          insertedMemberNote.memberId = memberId;
+          insertedMemberNote.authorId = memberId;
+          insertedMemberNote.type = 'outbound';
+          insertedMemberNote.status = 'missed';
+          await manager.save(insertedMemberNote);
+        });
+
+        const insertedContract = new Contract();
+        insertedContract.appId = app.id;
+        insertedContract.name = '私塾課合約2020';
+        insertedContract.description = '私塾課合約2020';
+        insertedContract.template = '<div> 1 </div>';
+        await manager.save(insertedContract);
+
+        memberIds.map(async (memberId) => {
+          const insertedMemberContract = new MemberContract();
+          insertedMemberContract.memberId = memberId;
+          insertedMemberContract.contract = insertedContract;
+          insertedMemberContract.agreedAt = new Date();
+          await manager.save(insertedMemberContract);
+        });
+
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .send({
+            memberIds: memberIds,
+            appId: app.id,
+          })
+          .expect(201);
+
+        expect(res.body).toHaveProperty('memberProperty');
+        expect(res.body.memberProperty).toHaveLength(5);
+        res.body.memberProperty.forEach((property) => {
+          expect(property).toHaveProperty('value');
+          expect(property).toHaveProperty('name');
+          expect(property).toHaveProperty('memberId');
+          expect(property).toHaveProperty('propertyId');
+          expect(property.value).toEqual('ccccc');
+          expect(property.name).toEqual('aaaa');
+        });
+
+        expect(res.body).toHaveProperty('memberTask');
+        expect(res.body.memberTask).toHaveLength(5);
+        res.body.memberTask.forEach((task) => {
+          expect(task).toHaveProperty('memberId');
+          expect(task).toHaveProperty('status');
+          expect(task.status).toEqual('done');
+        });
+
+        expect(res.body).toHaveProperty('memberPhone');
+        expect(res.body.memberPhone).toHaveLength(5);
+        res.body.memberPhone.forEach((phone) => {
+          expect(phone).toHaveProperty('memberId');
+          expect(phone).toHaveProperty('phone');
+          expect(phone.phone).toMatch(/^0900000000\d$/);
+        });
+
+        expect(res.body).toHaveProperty('memberNote');
+        expect(res.body.memberNote).toHaveLength(5);
+        res.body.memberNote.forEach((note) => {
+          expect(note).toHaveProperty('memberId');
+          expect(note).toHaveProperty('description');
+          expect(note.description).toBeNull();
+        });
+
+        expect(res.body).toHaveProperty('memberCategory');
+        expect(res.body.memberCategory).toHaveLength(5);
+        res.body.memberCategory.forEach((category) => {
+          expect(category).toHaveProperty('memberId');
+          expect(category).toHaveProperty('categoryId');
+          expect(category.name).toEqual('bbbb');
+          expect(category.categoryId).toBeTruthy();
+        });
+
+        expect(res.body).toHaveProperty('activeMemberContract');
+        expect(res.body.activeMemberContract).toHaveLength(5);
+        res.body.activeMemberContract.forEach((contract) => {
+          expect(contract).toHaveProperty('memberId');
+          expect(contract).toHaveProperty('agreed_at');
+          expect(contract).toHaveProperty('revoked_at');
+          expect(contract).toHaveProperty('values');
+          expect(contract.agreed_at).toBeTruthy();
+          expect(contract.revoked_at).toBeNull();
+        });
+      });
+      it('should handle an empty member list gracefully', async () => {
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .send({
+            memberIds: [],
+            appId: app.id,
+          })
+          .expect(201);
+
+        expect(res.body).toHaveProperty('memberProperty');
+        expect(res.body.memberProperty).toEqual([]);
+
+        expect(res.body).toHaveProperty('memberTask');
+        expect(res.body.memberTask).toEqual([]);
+
+        expect(res.body).toHaveProperty('memberPhone');
+        expect(res.body.memberPhone).toEqual([]);
+
+        expect(res.body).toHaveProperty('memberNote');
+        expect(res.body.memberNote).toEqual([]);
+
+        expect(res.body).toHaveProperty('memberCategory');
+        expect(res.body.memberCategory).toEqual([]);
+
+        expect(res.body).toHaveProperty('activeMemberContract');
+        expect(res.body.activeMemberContract).toEqual([]);
+      });
+      it('should return an empty array for memberProperty and memberCategory when there are no properties and categories', async () => {
+        const memberIds = [];
+        for (let i = 0; i < 5; i++) {
+          const insertedMember = new Member();
+          insertedMember.appId = app.id;
+          insertedMember.id = v4(); // 假设 v4() 是一个 UUID 生成函数
+          insertedMember.name = `name${i}`;
+          insertedMember.username = `username${i}`;
+          insertedMember.email = `email${i}@example.com`;
+          insertedMember.role = 'general-member';
+          insertedMember.star = 0;
+          insertedMember.createdAt = new Date();
+          insertedMember.loginedAt = new Date();
+          await manager.save(insertedMember);
+          memberIds.push(insertedMember.id);
+        }
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .send({
+            memberIds: memberIds,
+            appId: app.id,
+          })
+          .expect(201);
+
+        expect(res.body).toHaveProperty('memberProperty');
+        expect(res.body.memberProperty).toEqual([]);
+        expect(res.body.memberCategory).toEqual([]);
+      });
+    });
+
+    describe('Fail scenarios', () => {
+      it('should return an error for invalid member IDs type', async () => {
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .send({
+            memberIds: '',
+            appId: app.id,
+          })
+          .expect(400);
+
+        expect(res.body.message).toEqual(['memberIds must be an array']);
+      });
+      it('should return an error for missing required fields', async () => {
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .expect(400);
+
+        expect(res.body.message).toEqual(['memberIds must be an array', 'appId must be a string']);
+      });
+      it('should return error when appId is empty', async () => {
+        const jwtSecret = application
+          .get<ConfigService<{ HASURA_JWT_SECRET: string }>>(ConfigService)
+          .getOrThrow('HASURA_JWT_SECRET');
+
+        const token = jwt.sign(
+          {
+            appId: app.id,
+            memberId: 'invoker_member_id',
+            permissions: ['MEMBER_ADMIN'],
+          },
+          jwtSecret,
+        );
+
+        const res = await request(application.getHttpServer())
+          .post(route)
+          .set('Authorization', `Bearer ${token}`)
+          .set('host', appHost.host)
+          .send({
+            memberIds: [],
+            appId: '',
+          })
+          .expect(400);
+
+        expect(res.body.message).toEqual('Invalid request parameters');
+        expect(res.body.errors).toEqual(['appId must be a string and cannot be empty']);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 描述
[trello](https://trello.com/c/wTXClpDl)
由於名單撥打速度比較慢(hasura)，故使用lodstar-server改善這個問題
## 方式

- 經觀察會慢的主要原因是放入 member_id 的數量過多，導致就算有index也會因為他要去好幾頁翻，才能翻到資料
- 使用 values clause 的方式可以讓sql使用全表搜尋，會比使用index還快(部分情況）
- 但member property經實測使用index會比較快

## 反應時間
- 使用學米 - rita 帳號，api回應時間約莫 2-3秒

## 測試

- Success scenarios
  - should return data successfully for a valid request
  - should handle an empty member list gracefully
  - should return an empty array for memberProperty and memberCategory when there are no properties and categories
 - Fail scenarios
   - should return an error for invalid member IDs type
   - should return an error for missing required fields
