### PR TITLE
feat: log in finally block , ensure any request can log once

### DIFF
--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -32,6 +32,7 @@ import { APIException } from '~/api.excetion';
 import { category } from 'test/data';
 import dayjs from 'dayjs';
 import { MemberAuditLog } from './entity/member_audit_log.entity';
+import { ExecutorInfo, DeleteMemberInfo } from './member.type';
 
 @Injectable()
 export class MemberService {
@@ -353,24 +354,12 @@ export class MemberService {
   }
 
   async logMemberDeletionEventInfo(
-    deleteMemberEmail: string,
-    deleteMemberAppId: string,
-    executorMemberId: string,
-    executorIpAddress: string,
-    executorDateTime: Date,
-    action: 'create' | 'update',
-    updateId: string | null,
-    updateInfo: string,
+    deleteMemberInfo: DeleteMemberInfo,
+    executorMemberInfo: ExecutorInfo,
   ): Promise<MemberAuditLog | null> {
     const auditLog = await this.memberInfra.logMemberDeletionEventInfo(
-      deleteMemberEmail,
-      deleteMemberAppId,
-      executorMemberId,
-      executorIpAddress,
-      executorDateTime,
-      action,
-      updateId,
-      updateInfo,
+      deleteMemberInfo,
+      executorMemberInfo,
       this.entityManager,
     );
 

--- a/src/member/member.type.ts
+++ b/src/member/member.type.ts
@@ -42,3 +42,15 @@ export class PublicMember {
   @IsString()
   isBusiness: boolean;
 }
+export interface DeleteMemberInfo {
+  email: string;
+  id: string;
+  appId: string;
+}
+
+export interface ExecutorInfo {
+  memberId: string;
+  ipAddress: string;
+  dateTime: Date;
+  executeResult: string;
+}


### PR DESCRIPTION
# refactor 

由於 `logMemberDeletionEventInfo` 方法參數action的  create | update  會與資料表 `member_audit_log` action欄位產生誤會，故換一個方式執行 logMemberDeletionEventInfo 

使用 try block 的 `finally` block 執行  `logMemberDeletionEventInfo` 讓每次request 都一定會 執行一次，這樣就不用先create在update member_audit_log