### PR TITLE
fix: enrollment count

### DIFF
--- a/src/activity/activity.infra.ts
+++ b/src/activity/activity.infra.ts
@@ -147,7 +147,7 @@ export class ActivityInfrastructure {
   async getActivityParticipantsByActivityIds(
     manager: EntityManager,
     activityIds: string[],
-  ): Promise<Map<string, ActivitySessionTicketEnrollmentCount>> {
+  ): Promise<Map<string, ActivitySessionTicketEnrollmentCount[]>> {
     if (activityIds.length === 0) {
       return new Map();
     }
@@ -158,9 +158,14 @@ export class ActivityInfrastructure {
       .where('enrollmentCount.activityId IN (:...activityIds)', { activityIds })
       .getMany();
 
-    const enrollmentCountMap = new Map<string, ActivitySessionTicketEnrollmentCount>();
+    const enrollmentCountMap = new Map<string, ActivitySessionTicketEnrollmentCount[]>();
+
     sessionTicketEnrollmentCounts.forEach((count) => {
-      enrollmentCountMap.set(count.activityId, count);
+      const activityId = count.activityId;
+      if (!enrollmentCountMap.has(activityId)) {
+        enrollmentCountMap.set(activityId, []);
+      }
+      enrollmentCountMap.get(activityId)?.push(count);
     });
 
     return enrollmentCountMap;

--- a/test/activity/controller.e2e-spec.ts
+++ b/test/activity/controller.e2e-spec.ts
@@ -150,6 +150,10 @@ describe('ActivityController (e2e)', () => {
         role: 'app-owner',
       });
 
+      const insertedMember2 = await createTestMember(manager, {
+        appId: app.id,
+      });
+
       const insertedActivity = await createTestActivity(manager, {
         app: app,
         organizer: insertedMember,
@@ -198,8 +202,19 @@ describe('ActivityController (e2e)', () => {
         appId: app.id,
       });
 
+      const insertedOrderLog2 = await createTestOrderLog(manager, {
+        member: insertedMember2,
+        appId: app.id,
+      });
+
       const insertedProduct = await createTestProduct(manager, {
         id: `ActivityTicket_${insertedActivityTicket1.id}`,
+        type: 'ActivityTicket',
+        target: insertedActivityTicket1.id,
+      });
+
+      const insertedProduct2 = await createTestProduct(manager, {
+        id: `ActivityTicket_${insertedActivityTicket2.id}`,
         type: 'ActivityTicket',
         target: insertedActivityTicket1.id,
       });
@@ -211,6 +226,18 @@ describe('ActivityController (e2e)', () => {
       const insertedOrderProduct = await createTestOrderProduct(manager, {
         order: insertedOrderLog,
         product: insertedProduct,
+        currency: insertedCurrency,
+        productId: insertedActivity.id,
+        options: {
+          from: `/activities/${insertedActivity.id}`,
+          currencyId: insertedCurrency.id,
+          currencyPrice: 2000,
+        },
+      });
+
+      const insertedOrderProduct2 = await createTestOrderProduct(manager, {
+        order: insertedOrderLog2,
+        product: insertedProduct2,
         currency: insertedCurrency,
         productId: insertedActivity.id,
         options: {
@@ -241,8 +268,8 @@ describe('ActivityController (e2e)', () => {
               insertedActivitySessionTicket2.activitySessionType,
             ],
             participantsCount: {
-              online: '0',
-              offline: '1',
+              online: 1,
+              offline: 1,
             },
             startedAt: insertedActivitySession1.startedAt.toISOString(),
             endedAt: insertedActivitySession2.endedAt.toISOString(),


### PR DESCRIPTION
# 描述
參與活動的人數不正確

# 原因
由於`activity` 與 `activity_session_ticket_enrollment_count`  的關係為一對多 
若使用 `enrollmentCountMap.set(count.activityId, count)` 後面同樣的 activity_id 將會覆蓋掉已經set入map的資料

# 修改
使用陣列去存
```js
    sessionTicketEnrollmentCounts.forEach((count) => {
      const activityId = count.activityId;
      if (!enrollmentCountMap.has(activityId)) {
        enrollmentCountMap.set(activityId, []);
      }
      enrollmentCountMap.get(activityId)?.push(count);
    });
```
並用reduce去加總
```js
      const { totalOnlineCount, totalOfflineCount } = sessionTicketEnrollmentCounts.reduce(
        (acc, count) => {
          acc.totalOnlineCount += Number(count.activityOnlineSessionTicketCount);
          acc.totalOfflineCount += Number(count.activityOfflineSessionTicketCount);
          return acc;
        },
        { totalOnlineCount: 0, totalOfflineCount: 0 },
      );
```