### PR TITLE
track program process / (2) refactor: porter runner command

### DIFF
--- a/src/runner/porter-command/portLastLoggedInCommand.ts
+++ b/src/runner/porter-command/portLastLoggedInCommand.ts
@@ -1,0 +1,40 @@
+import { CacheService } from '~/utility/cache/cache.service';
+import { MemberService } from '~/member/member.service';
+import { EntityManager } from 'typeorm';
+import { PorterCommand } from './porterCommandInterface';
+
+class PortLastLoggedInCommand implements PorterCommand {
+  constructor(private readonly cacheService: CacheService, private readonly memberService: MemberService) {}
+
+  public async execute(manager: EntityManager, batchSize = 1000): Promise<void> {
+    let cursor = '0';
+    do {
+      const reply = await this.cacheService.getClient().scan(cursor, 'MATCH', 'last-logged-in:*', 'COUNT', batchSize);
+      cursor = reply[0];
+      const keys = reply[1];
+
+      if (keys.length === 0) {
+        console.warn('No last logged in member keys found');
+        break;
+      }
+
+      const timestamps = await this.cacheService.getClient().mget(keys);
+
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const [, memberId] = key.split(':');
+        const loginedAt = timestamps[i];
+
+        try {
+          await this.memberService.updateMemberLoginDate(memberId, new Date(loginedAt), manager);
+          await this.cacheService.getClient().del(key);
+        } catch (error) {
+          console.error(`porting ${key} failed:`, error);
+          await this.cacheService.getClient().del(key);
+        }
+      }
+    } while (cursor !== '0');
+  }
+}
+
+export { PortLastLoggedInCommand };

--- a/src/runner/porter-command/portPhoneServiceInsertEventCommand.ts
+++ b/src/runner/porter-command/portPhoneServiceInsertEventCommand.ts
@@ -1,0 +1,169 @@
+import { CacheService } from '~/utility/cache/cache.service';
+import { EntityManager, In } from 'typeorm';
+import { MemberNote } from '~/entity/MemberNote';
+import { MemberInfrastructure } from '~/member/member.infra';
+import { Member } from '~/member/entity/member.entity';
+import { PorterCommand } from './porterCommandInterface';
+
+type LastMemberNotesType = {
+  criteria: {
+    id: any;
+    appId: string;
+  };
+  lastMemberRecord: {
+    lastMemberNoteAnswered?: string | undefined;
+    lastMemberNoteCalled?: string | undefined;
+    lastMemberNoteCreated: string;
+  };
+};
+
+type ErrInfoType = {
+  memberNote: { data: MemberNote[]; errMsg: string } | 'NoError';
+  member: { data: LastMemberNotesType; errMsg: string } | 'NoError';
+};
+
+type ErrorLogType = {
+  key: string;
+  date: string;
+  info: ErrInfoType | 'No data found' | 'Data format error';
+};
+
+type redisDataType = {
+  key?: string;
+  memberNotes: MemberNote[];
+  lastMemberNotes: LastMemberNotesType;
+};
+
+class PortPhoneServiceInsertEventCommand implements PorterCommand {
+  constructor(private readonly memberInfra: MemberInfrastructure, private readonly cacheService: CacheService) {}
+
+  public async execute(manager: EntityManager, batchSize = 1000): Promise<void> {
+    const hasRedisDataProperty = (data: redisDataType): boolean => {
+      return Boolean(
+        data.hasOwnProperty('lastMemberNotes') &&
+          data.lastMemberNotes?.hasOwnProperty('criteria') &&
+          data.lastMemberNotes?.hasOwnProperty('lastMemberRecord') &&
+          data.hasOwnProperty('memberNotes'),
+      );
+    };
+
+    const createErrorLog = (key: string): ErrorLogType => {
+      const dateTime = key.split(':')[1];
+      const errorLog: ErrorLogType = {
+        key,
+        date: `${new Date(parseInt(dateTime, 10))}`,
+        info: {
+          memberNote: 'NoError',
+          member: 'NoError',
+        },
+      };
+      return errorLog;
+    };
+
+    const client = this.cacheService.getClient();
+    const pattern = `PhoneService:*`;
+    let cursor = '0';
+
+    do {
+      const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+      const redisDataArray: redisDataType[] = [];
+      const errorLogs: ErrorLogType[] = [];
+
+      // handle data from redis
+      for (const key of keys) {
+        const valueString = await client.get(key);
+
+        if (!valueString) {
+          const errorLog = createErrorLog(key);
+          errorLog.info = 'No data found';
+          errorLogs.push(errorLog);
+          continue;
+        }
+        const data: redisDataType = JSON.parse(valueString);
+
+        if (!hasRedisDataProperty(data)) {
+          const errorLog = createErrorLog(key);
+          errorLog.info = 'Data format error';
+          errorLogs.push(errorLog);
+          continue;
+        }
+
+        data.key = key;
+        redisDataArray.push(data);
+      }
+
+      // save data to DB
+      await Promise.all(
+        redisDataArray.map(
+          async (data) =>
+            await manager.transaction(async (manager) => {
+              try {
+                const { memberNotes, lastMemberNotes, key } = data;
+                const {
+                  criteria: { id, appId },
+                  lastMemberRecord: { lastMemberNoteCreated, lastMemberNoteCalled, lastMemberNoteAnswered },
+                } = lastMemberNotes;
+                let errorLog = createErrorLog(key);
+
+                try {
+                  await this.memberInfra.insertData<MemberNote>(memberNotes, MemberNote, manager);
+                } catch (error) {
+                  errorLog = {
+                    ...errorLog,
+                    info: {
+                      member: (errorLog.info as Pick<ErrInfoType, 'member'>).member,
+                      memberNote: { data: memberNotes, errMsg: error.toString() },
+                    },
+                  };
+                }
+                try {
+                  await this.memberInfra.updateData<Member>(
+                    { id: In(id), appId },
+                    {
+                      lastMemberNoteCreated: lastMemberNoteCreated && new Date(lastMemberNoteCreated),
+                      lastMemberNoteCalled: lastMemberNoteCalled && new Date(lastMemberNoteCalled),
+                      lastMemberNoteAnswered: lastMemberNoteAnswered && new Date(lastMemberNoteAnswered),
+                    },
+                    Member,
+                    manager,
+                  );
+                } catch (error) {
+                  errorLog = {
+                    ...errorLog,
+                    info: {
+                      member: { data: lastMemberNotes, errMsg: error.toString() },
+                      memberNote: (errorLog.info as Pick<ErrInfoType, 'memberNote'>).memberNote,
+                    },
+                  };
+                }
+
+                if (
+                  typeof errorLog.info !== 'string' &&
+                  (typeof errorLog.info.member !== 'string' || typeof errorLog.info.memberNote !== 'string')
+                ) {
+                  errorLogs.push(errorLog);
+                }
+
+                await client.del(key);
+              } catch (error) {
+                // Data rollback
+                throw new Error(`Encountered an issue while handling member or memberNote data: ${error.message}`);
+              }
+            }),
+        ),
+      );
+
+      if (errorLogs.length > 0) {
+        for (const errorItem of errorLogs) {
+          console.error(`Saving phone service failed:${errorItem}`);
+        }
+      }
+      redisDataArray.length = 0;
+      errorLogs.length = 0;
+    } while (cursor !== '0');
+  }
+}
+
+export { PortPhoneServiceInsertEventCommand };

--- a/src/runner/porter-command/portPlayerEventCommand.ts
+++ b/src/runner/porter-command/portPlayerEventCommand.ts
@@ -1,0 +1,46 @@
+import { EntityManager } from 'typeorm';
+import { PorterProgramService } from '~/program/porter-program.service';
+import { ProgramInfrastructure } from '~/program/program.infra';
+import { PorterCommand } from './porterCommandInterface';
+
+class PortPlayerEventCommand implements PorterCommand {
+  constructor(
+    private readonly porterProgramService: PorterProgramService,
+    private readonly programInfra: ProgramInfrastructure,
+  ) {}
+
+  public async execute(manager: EntityManager, batchSize = 1000): Promise<void> {
+    const pattern = 'program-content-event:*:program-content:*:*';
+    let cursor = '0';
+
+    do {
+      const [newCursor, keys] = await this.porterProgramService.scanCacheForKeys(pattern, batchSize, cursor);
+      cursor = newCursor;
+
+      if (keys.length > 0) {
+        const values = await this.porterProgramService.fetchValuesFromCache(keys);
+        const keyValuePairs = this.porterProgramService.parseKeyValuePairs(keys, values);
+        const programContentIds = new Set(keyValuePairs.map((kvp) => kvp.programContentId));
+        const programContentsMap = await this.porterProgramService.fetchProgramContents(
+          Array.from(programContentIds),
+          manager,
+        );
+        const programContentLogs = this.porterProgramService.createProgramContentLogs(
+          keyValuePairs,
+          programContentsMap,
+        );
+
+        if (programContentLogs.length > 0) {
+          try {
+            await this.programInfra.saveProgramContentLogs(programContentLogs, manager);
+            await this.porterProgramService.deleteProcessedKeysFromCache(keys);
+          } catch (error) {
+            await this.porterProgramService.handleBatchSaveFailure(programContentLogs, keys, manager);
+          }
+        }
+      }
+    } while (cursor !== '0');
+  }
+}
+
+export { PortPlayerEventCommand };

--- a/src/runner/porter-command/portPodcastProgramCommand.ts
+++ b/src/runner/porter-command/portPodcastProgramCommand.ts
@@ -1,0 +1,65 @@
+import { CacheService } from '~/utility/cache/cache.service';
+import { EntityManager } from 'typeorm';
+import { PodcastService } from '~/podcast/podcast.service';
+import { PorterCommand } from './porterCommandInterface';
+
+class PortPodcastProgramCommand implements PorterCommand {
+  constructor(private readonly cacheService: CacheService, private readonly podcastService: PodcastService) {}
+
+  public async execute(manager: EntityManager, batchSize = 1000): Promise<void> {
+    const pattern = 'podcast-program-event:*:podcast-program:*:*';
+    const client = this.cacheService.getClient();
+    let cursor = '0';
+
+    do {
+      const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+      const progressInfoList = [];
+
+      for (const key of keys) {
+        const valueString = await client.get(key);
+        if (!valueString) continue;
+
+        const [, memberId, , podcastProgramId, createdAtString] = key.split(':');
+        const createdAtTimestamp = parseInt(createdAtString, 10);
+        const createdAtDate = new Date(createdAtTimestamp);
+
+        const value = JSON.parse(valueString);
+        progressInfoList.push({
+          key,
+          memberId,
+          podcastProgramId,
+          progress: value?.progress,
+          lastProgress: value?.lastProgress,
+          podcastAlbumId: value?.podcastAlbumId,
+          created_at: createdAtDate,
+        });
+      }
+
+      progressInfoList.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+
+      if (progressInfoList.length > 0) {
+        try {
+          await this.podcastService.processPodcastProgramProgress(progressInfoList, manager);
+          await client.del(...progressInfoList.map((info) => info.key));
+        } catch (error) {
+          console.error('Batch saving failed:', error);
+          for (const progressInfo of progressInfoList) {
+            try {
+              await this.podcastService.processPodcastProgramProgress([progressInfo], manager);
+            } catch (innerError) {
+              console.error(
+                `Saving progress for ${progressInfo.key} , value ${JSON.stringify(progressInfo)} failed:`,
+                innerError,
+              );
+            }
+            await client.del(progressInfo.key);
+          }
+        }
+      }
+    } while (cursor !== '0');
+  }
+}
+
+export { PortPodcastProgramCommand };

--- a/src/runner/porter-command/porterCommandInterface.ts
+++ b/src/runner/porter-command/porterCommandInterface.ts
@@ -1,0 +1,5 @@
+import { EntityManager } from 'typeorm';
+
+export interface PorterCommand {
+  execute(manager: EntityManager): Promise<void>;
+}

--- a/src/runner/porter.runner.ts
+++ b/src/runner/porter.runner.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { DistributedLockService } from '~/utility/lock/distributed_lock.service';
 import { ShutdownService } from '~/utility/shutdown/shutdown.service';
@@ -7,18 +7,18 @@ import { Runner } from './runner';
 import { CacheService } from '~/utility/cache/cache.service';
 import axios from 'axios';
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { EntityManager, FindOperator, In, LessThan } from 'typeorm';
-import { ProgramContentLog } from '~/program/entity/ProgramContentLog';
+import { EntityManager } from 'typeorm';
 import { MemberService } from '~/member/member.service';
-import { ProgramService } from '~/program/program.service';
 import { PodcastService } from '~/podcast/podcast.service';
-import { PodcastProgressInfo } from '~/podcast/podcast.types';
 import { PorterProgramService } from '~/program/porter-program.service';
 import { ProgramInfrastructure } from '~/program/program.infra';
 import { MemberInfrastructure } from '~/member/member.infra';
 import dayjs from 'dayjs';
-import { MemberNote } from '~/entity/MemberNote';
-import { Member } from '~/member/entity/member.entity';
+import { PortLastLoggedInCommand } from './porter-command/PortLastLoggedInCommand';
+import { PortPlayerEventCommand } from './porter-command/portPlayerEventCommand';
+import { PortPhoneServiceInsertEventCommand } from './porter-command/portPhoneServiceInsertEventCommand';
+import { PortPodcastProgramCommand } from './porter-command/portPodcastProgramCommand';
+import { PorterCommand } from './porter-command/porterCommandInterface';
 
 @Injectable()
 export class PorterRunner extends Runner {
@@ -28,133 +28,13 @@ export class PorterRunner extends Runner {
     protected readonly shutdownService: ShutdownService,
     private readonly cacheService: CacheService,
     private readonly memberService: MemberService,
-    private readonly programService: ProgramService,
-    private readonly podcastService: PodcastService,
     private readonly porterProgramService: PorterProgramService,
     private readonly programInfra: ProgramInfrastructure,
     private readonly memberInfra: MemberInfrastructure,
-
+    private readonly podcastService: PodcastService,
     @InjectEntityManager() private readonly entityManager: EntityManager,
   ) {
     super(PorterRunner.name, 5 * 60 * 1000, logger, distributedLockService, shutdownService);
-  }
-
-  async portLastLoggedIn(manager: EntityManager, batchSize = 1000): Promise<void> {
-    let cursor = '0';
-    do {
-      const reply = await this.cacheService.getClient().scan(cursor, 'MATCH', 'last-logged-in:*', 'COUNT', batchSize);
-      cursor = reply[0];
-      const keys = reply[1];
-
-      if (keys.length === 0) {
-        console.warn('No last logged in member keys found');
-        break;
-      }
-
-      const timestamps = await this.cacheService.getClient().mget(keys);
-
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        const [, memberId] = key.split(':');
-        const loginedAt = timestamps[i];
-
-        try {
-          await this.memberService.updateMemberLoginDate(memberId, new Date(loginedAt), manager);
-          await this.cacheService.getClient().del(key);
-        } catch (error) {
-          console.error(`porting ${key} failed:`, error);
-          await this.cacheService.getClient().del(key);
-        }
-      }
-    } while (cursor !== '0');
-  }
-
-  async portPlayerEvent(manager: EntityManager, batchSize = 1000): Promise<void> {
-    const pattern = 'program-content-event:*:program-content:*:*';
-    let cursor = '0';
-
-    do {
-      const [newCursor, keys] = await this.porterProgramService.scanCacheForKeys(pattern, batchSize, cursor);
-      cursor = newCursor;
-
-      if (keys.length > 0) {
-        const values = await this.porterProgramService.fetchValuesFromCache(keys);
-        const keyValuePairs = this.porterProgramService.parseKeyValuePairs(keys, values);
-        const programContentIds = new Set(keyValuePairs.map((kvp) => kvp.programContentId));
-        const programContentsMap = await this.porterProgramService.fetchProgramContents(
-          Array.from(programContentIds),
-          manager,
-        );
-        const programContentLogs = this.porterProgramService.createProgramContentLogs(
-          keyValuePairs,
-          programContentsMap,
-        );
-
-        if (programContentLogs.length > 0) {
-          try {
-            await this.programInfra.saveProgramContentLogs(programContentLogs, manager);
-            await this.porterProgramService.deleteProcessedKeysFromCache(keys);
-          } catch (error) {
-            await this.porterProgramService.handleBatchSaveFailure(programContentLogs, keys, manager);
-          }
-        }
-      }
-    } while (cursor !== '0');
-  }
-
-  async portPodcastProgram(manager: EntityManager, batchSize = 1000): Promise<void> {
-    const pattern = 'podcast-program-event:*:podcast-program:*:*';
-    const client = this.cacheService.getClient();
-    let cursor = '0';
-
-    do {
-      const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
-      cursor = scanResult[0];
-      const keys = scanResult[1];
-      const progressInfoList = [];
-
-      for (const key of keys) {
-        const valueString = await client.get(key);
-        if (!valueString) continue;
-
-        const [, memberId, , podcastProgramId, createdAtString] = key.split(':');
-        const createdAtTimestamp = parseInt(createdAtString, 10);
-        const createdAtDate = new Date(createdAtTimestamp);
-
-        const value = JSON.parse(valueString);
-        progressInfoList.push({
-          key,
-          memberId,
-          podcastProgramId,
-          progress: value?.progress,
-          lastProgress: value?.lastProgress,
-          podcastAlbumId: value?.podcastAlbumId,
-          created_at: createdAtDate,
-        });
-      }
-
-      progressInfoList.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
-
-      if (progressInfoList.length > 0) {
-        try {
-          await this.podcastService.processPodcastProgramProgress(progressInfoList, manager);
-          await client.del(...progressInfoList.map((info) => info.key));
-        } catch (error) {
-          console.error('Batch saving failed:', error);
-          for (const progressInfo of progressInfoList) {
-            try {
-              await this.podcastService.processPodcastProgramProgress([progressInfo], manager);
-            } catch (innerError) {
-              console.error(
-                `Saving progress for ${progressInfo.key} , value ${JSON.stringify(progressInfo)} failed:`,
-                innerError,
-              );
-            }
-            await client.del(progressInfo.key);
-          }
-        }
-      }
-    } while (cursor !== '0');
   }
 
   async checkAndCallHeartbeat(): Promise<void> {
@@ -177,189 +57,29 @@ export class PorterRunner extends Runner {
     }
   }
 
-  async portPhoneServiceInsertEvent(manager: EntityManager, batchSize = 1000): Promise<void> {
-    type LastMemberNotesType = {
-      criteria: {
-        id: any;
-        appId: string;
-      };
-      lastMemberRecord: {
-        lastMemberNoteAnswered?: string | undefined;
-        lastMemberNoteCalled?: string | undefined;
-        lastMemberNoteCreated: string;
-      };
-    };
-
-    type ErrInfoType = {
-      memberNote: { data: MemberNote[]; errMsg: string } | 'NoError';
-      member: { data: LastMemberNotesType; errMsg: string } | 'NoError';
-    };
-
-    type ErrorLogType = {
-      key: string;
-      date: string;
-      info: ErrInfoType | 'No data found' | 'Data format error';
-    };
-
-    type redisDataType = {
-      key?: string;
-      memberNotes: MemberNote[];
-      lastMemberNotes: LastMemberNotesType;
-    };
-
-    const hasRedisDataProperty = (data: redisDataType): boolean => {
-      return Boolean(
-        data.hasOwnProperty('lastMemberNotes') &&
-          data.lastMemberNotes?.hasOwnProperty('criteria') &&
-          data.lastMemberNotes?.hasOwnProperty('lastMemberRecord') &&
-          data.hasOwnProperty('memberNotes'),
-      );
-    };
-
-    const createErrorLog = (key: string): ErrorLogType => {
-      const dateTime = key.split(':')[1];
-      const errorLog: ErrorLogType = {
-        key,
-        date: `${new Date(parseInt(dateTime, 10))}`,
-        info: {
-          memberNote: 'NoError',
-          member: 'NoError',
-        },
-      };
-      return errorLog;
-    };
-
-    const client = this.cacheService.getClient();
-    const pattern = `PhoneService:*`;
-    let cursor = '0';
-
-    do {
-      const scanResult = await client.scan(cursor, 'MATCH', pattern, 'COUNT', batchSize);
-      cursor = scanResult[0];
-      const keys = scanResult[1];
-      const redisDataArray: redisDataType[] = [];
-      const errorLogs: ErrorLogType[] = [];
-
-      // handle data from redis
-      for (const key of keys) {
-        const valueString = await client.get(key);
-
-        if (!valueString) {
-          const errorLog = createErrorLog(key);
-          errorLog.info = 'No data found';
-          errorLogs.push(errorLog);
-          continue;
-        }
-        const data: redisDataType = JSON.parse(valueString);
-
-        if (!hasRedisDataProperty(data)) {
-          const errorLog = createErrorLog(key);
-          errorLog.info = 'Data format error';
-          errorLogs.push(errorLog);
-          continue;
-        }
-
-        data.key = key;
-        redisDataArray.push(data);
-      }
-
-      // save data to DB
-      await Promise.all(
-        redisDataArray.map(
-          async (data) =>
-            await manager.transaction(async (manager) => {
-              try {
-                const { memberNotes, lastMemberNotes, key } = data;
-                const {
-                  criteria: { id, appId },
-                  lastMemberRecord: { lastMemberNoteCreated, lastMemberNoteCalled, lastMemberNoteAnswered },
-                } = lastMemberNotes;
-                let errorLog = createErrorLog(key);
-
-                try {
-                  await this.memberInfra.insertData<MemberNote>(memberNotes, MemberNote, manager);
-                } catch (error) {
-                  errorLog = {
-                    ...errorLog,
-                    info: {
-                      member: (errorLog.info as Pick<ErrInfoType, 'member'>).member,
-                      memberNote: { data: memberNotes, errMsg: error.toString() },
-                    },
-                  };
-                }
-                try {
-                  await this.memberInfra.updateData<Member>(
-                    { id: In(id), appId },
-                    {
-                      lastMemberNoteCreated: lastMemberNoteCreated && new Date(lastMemberNoteCreated),
-                      lastMemberNoteCalled: lastMemberNoteCalled && new Date(lastMemberNoteCalled),
-                      lastMemberNoteAnswered: lastMemberNoteAnswered && new Date(lastMemberNoteAnswered),
-                    },
-                    Member,
-                    manager,
-                  );
-                } catch (error) {
-                  errorLog = {
-                    ...errorLog,
-                    info: {
-                      member: { data: lastMemberNotes, errMsg: error.toString() },
-                      memberNote: (errorLog.info as Pick<ErrInfoType, 'memberNote'>).memberNote,
-                    },
-                  };
-                }
-
-                if (
-                  typeof errorLog.info !== 'string' &&
-                  (typeof errorLog.info.member !== 'string' || typeof errorLog.info.memberNote !== 'string')
-                ) {
-                  errorLogs.push(errorLog);
-                }
-
-                await client.del(key);
-              } catch (error) {
-                // Data rollback
-                throw new Error(`Encountered an issue while handling member or memberNote data: ${error.message}`);
-              }
-            }),
-        ),
-      );
-
-      if (errorLogs.length > 0) {
-        for (const errorItem of errorLogs) {
-          console.error(`Saving phone service failed:${errorItem}`);
-        }
-      }
-      redisDataArray.length = 0;
-      errorLogs.length = 0;
-    } while (cursor !== '0');
-  }
-
-  async execute(entityManager?: EntityManager): Promise<void> {
+  public async execute(entityManager?: EntityManager): Promise<void> {
     console.time('Total Execution Time');
     const currentTime = dayjs().format('YYYY-MM-DD HH:mm:ss');
     console.log(`start porter runner ${currentTime}`);
     await this.checkAndCallHeartbeat();
 
+    const commands: PorterCommand[] = [
+      new PortLastLoggedInCommand(this.cacheService, this.memberService),
+      new PortPlayerEventCommand(this.porterProgramService, this.programInfra),
+      new PortPhoneServiceInsertEventCommand(this.memberInfra, this.cacheService),
+      new PortPodcastProgramCommand(this.cacheService, this.podcastService),
+    ];
+
     const errors: any[] = [];
 
-    const handlePorting = async (taskName: string, taskFunction: () => Promise<void>) => {
-      const taskStartTime = currentTime;
-      console.time(`Task Time [${taskStartTime}] - ${taskName}`);
+    for (const command of commands) {
       try {
-        console.log(`porting ${taskName} at ${taskStartTime}`);
-        await taskFunction();
-        console.log(`finishing porting ${taskName}`);
+        await command.execute(this.entityManager);
       } catch (error) {
-        console.error(`port ${taskName} failed at ${taskStartTime}:`, error);
+        console.error('Porting errors occurred', error);
         errors.push(error);
       }
-      console.timeEnd(`Task Time [${taskStartTime}] - ${taskName}`);
-    };
-
-    await handlePorting('last logged in', () => this.portLastLoggedIn(this.entityManager));
-    await handlePorting('player event', () => this.portPlayerEvent(this.entityManager));
-    await handlePorting('podcast event', () => this.portPodcastProgram(this.entityManager));
-    await handlePorting('phone service event', () => this.portPhoneServiceInsertEvent(this.entityManager));
+    }
 
     if (errors.length > 0) {
       console.error(errors, 'Porting errors occurred');

--- a/src/runner/porter.runner.ts
+++ b/src/runner/porter.runner.ts
@@ -14,11 +14,11 @@ import { PorterProgramService } from '~/program/porter-program.service';
 import { ProgramInfrastructure } from '~/program/program.infra';
 import { MemberInfrastructure } from '~/member/member.infra';
 import dayjs from 'dayjs';
-import { PortLastLoggedInCommand } from './porter-command/PortLastLoggedInCommand';
-import { PortPlayerEventCommand } from './porter-command/portPlayerEventCommand';
-import { PortPhoneServiceInsertEventCommand } from './porter-command/portPhoneServiceInsertEventCommand';
-import { PortPodcastProgramCommand } from './porter-command/portPodcastProgramCommand';
-import { PorterCommand } from './porter-command/porterCommandInterface';
+import { PortLastLoggedInCommand } from '~/runner/porter-command/portLastLoggedInCommand';
+import { PortPlayerEventCommand } from '~/runner/porter-command/portPlayerEventCommand';
+import { PortPhoneServiceInsertEventCommand } from '~/runner/porter-command/portPhoneServiceInsertEventCommand';
+import { PortPodcastProgramCommand } from '~/runner/porter-command/portPodcastProgramCommand';
+import { PorterCommand } from '~/runner/porter-command/porterCommandInterface';
 
 @Injectable()
 export class PorterRunner extends Runner {

--- a/test/runner/porter_runner.e2e-spec.ts
+++ b/test/runner/porter_runner.e2e-spec.ts
@@ -279,7 +279,7 @@ describe('PorterRunner (e2e)', () => {
         }
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portLastLoggedIn(manager, 20);
+        await porterRunner.execute(manager);
 
         for (const memberId of members) {
           const updatedMember = await memberRepo.findOne({ where: { id: memberId } });
@@ -308,7 +308,7 @@ describe('PorterRunner (e2e)', () => {
         }
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portLastLoggedIn(manager, 20);
+        await porterRunner.execute(manager);
 
         const updatedMember = await memberRepo.findOne({ where: { id: memberId } });
         expect(updatedMember.loginedAt).toEqual(new Date(now.getTime() + 2 * 1000));
@@ -321,7 +321,7 @@ describe('PorterRunner (e2e)', () => {
         expect(keyExists).toBe(1);
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portLastLoggedIn(manager, 20);
+        await porterRunner.execute(manager);
 
         keyExists = await cacheService.getClient().exists(key);
         expect(keyExists).toBe(0);
@@ -341,7 +341,7 @@ describe('PorterRunner (e2e)', () => {
         const consoleSpy = jest.spyOn(console, 'error');
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portLastLoggedIn(manager, 20);
+        await porterRunner.execute(manager);
 
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining(`No records updated for memberId: ${nonExistentMemberId}. Member might not exist.`),
@@ -363,7 +363,7 @@ describe('PorterRunner (e2e)', () => {
         const consoleSpy = jest.spyOn(console, 'error');
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portLastLoggedIn(manager, 20);
+        await porterRunner.execute(manager);
 
         expect(consoleSpy).toHaveBeenCalled();
 
@@ -383,7 +383,7 @@ describe('PorterRunner (e2e)', () => {
     it('should correctly save program content log', async () => {
       const porterRunner = application.get<PorterRunner>(Runner);
 
-      await porterRunner.portPlayerEvent(manager, 30);
+      await porterRunner.execute(manager);
 
       const [latestLog] = await programContentLogRepo.find({
         order: { createdAt: 'DESC' },
@@ -412,7 +412,7 @@ describe('PorterRunner (e2e)', () => {
 
       const consoleSpy = jest.spyOn(console, 'error');
       const porterRunner = application.get<PorterRunner>(Runner);
-      await porterRunner.portPlayerEvent(manager);
+      await porterRunner.execute(manager);
 
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid timestamp'));
 
@@ -439,7 +439,7 @@ describe('PorterRunner (e2e)', () => {
         }
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPlayerEvent(manager, 20);
+        await porterRunner.execute(manager);
 
         const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
         expect(logs.length).toEqual(80);
@@ -468,7 +468,7 @@ describe('PorterRunner (e2e)', () => {
         }
         const consoleSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPlayerEvent(manager, 20);
+        await porterRunner.execute(manager);
 
         const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
         expect(logs.length).toEqual(79);
@@ -507,7 +507,7 @@ describe('PorterRunner (e2e)', () => {
         }
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPlayerEvent(manager, 20);
+        await porterRunner.execute(manager);
 
         const logs = await programContentLogRepo.find({ order: { createdAt: 'ASC' } });
         expect(logs.length).toEqual(79);
@@ -531,7 +531,7 @@ describe('PorterRunner (e2e)', () => {
 
         const porterRunner = application.get<PorterRunner>(Runner);
 
-        await expect(porterRunner.portPlayerEvent(manager)).resolves.not.toThrow();
+        await expect(porterRunner.execute(manager)).resolves.not.toThrow();
 
         const logs = await programContentLogRepo.find();
         expect(logs.length).toEqual(0);
@@ -576,7 +576,7 @@ describe('PorterRunner (e2e)', () => {
         }
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPodcastProgram(manager);
+        await porterRunner.execute(manager);
 
         const progressRecords = await podcastProgramProgressRepo.find();
         expect(progressRecords.length).toEqual(1);
@@ -631,7 +631,7 @@ describe('PorterRunner (e2e)', () => {
         }
         const consoleSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPodcastProgram(manager);
+        await porterRunner.execute(manager);
 
         const progressRecords = await podcastProgramProgressRepo.find();
         expect(progressRecords.length).toEqual(2);
@@ -662,7 +662,7 @@ describe('PorterRunner (e2e)', () => {
           );
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPodcastProgram(manager);
+        await porterRunner.execute(manager);
 
         const savedRecord = await podcastProgramProgressRepo.findOne({
           where: {
@@ -685,7 +685,7 @@ describe('PorterRunner (e2e)', () => {
 
         const porterRunner = application.get<PorterRunner>(Runner);
 
-        await expect(porterRunner.portPodcastProgram(manager)).resolves.not.toThrow();
+        await expect(porterRunner.execute(manager)).resolves.not.toThrow();
 
         const progressRecords = await podcastProgramProgressRepo.find();
         expect(progressRecords.length).toEqual(0);
@@ -743,7 +743,7 @@ describe('PorterRunner (e2e)', () => {
 
         const consoleSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await porterRunner.portPodcastProgram(manager);
+        await porterRunner.execute(manager);
 
         const progressRecords = await podcastProgramProgressRepo.find();
         expect(progressRecords.length).toEqual(2);
@@ -782,7 +782,7 @@ describe('PorterRunner (e2e)', () => {
 
         const logSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         expect(logSpy).not.toHaveBeenCalled();
         logSpy.mockRestore();
 
@@ -801,7 +801,7 @@ describe('PorterRunner (e2e)', () => {
         );
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         const scanRedisKey = await cacheService.getClient().keys('PhoneService:*');
         const remainingKeysCount = scanRedisKey.length;
         expect(remainingKeysCount).toEqual(0);
@@ -817,7 +817,7 @@ describe('PorterRunner (e2e)', () => {
         );
 
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         const _member = await memberRepo.findOne({ where: { name: 'testMember' } });
         expect(_member.id).toBe(memberNote.authorId);
         expect(_member.id).toBe(memberNote.memberId);
@@ -836,7 +836,7 @@ describe('PorterRunner (e2e)', () => {
 
         const logSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         expect(logSpy).toHaveBeenCalled();
         expect(logSpy).toBeCalledTimes(1);
         logSpy.mockRestore();
@@ -860,7 +860,7 @@ describe('PorterRunner (e2e)', () => {
         );
         const logSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         expect(logSpy).toHaveBeenCalled();
         expect(logSpy).toBeCalledTimes(1);
         logSpy.mockRestore();
@@ -878,7 +878,7 @@ describe('PorterRunner (e2e)', () => {
         }
         const logSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         expect(logSpy).toBeCalledTimes(20);
         logSpy.mockRestore();
       });
@@ -888,7 +888,7 @@ describe('PorterRunner (e2e)', () => {
 
         const logSpy = jest.spyOn(console, 'error');
         const porterRunner = application.get<PorterRunner>(Runner);
-        await expect(porterRunner.portPhoneServiceInsertEvent(manager, 1)).resolves.toBeUndefined();
+        await expect(porterRunner.execute(manager)).resolves.toBeUndefined();
         expect(logSpy).toHaveBeenCalled();
         expect(logSpy).toBeCalledTimes(1);
         logSpy.mockRestore();


### PR DESCRIPTION
# Porter Runner 需要被擴充

遇到的問題： 
 - Porter Runner 有非常多非內聚的部分，以下部分都非相關，但class 內部應為高內聚的行為集合
   - 紀錄登入
   - 紀錄program progress log 
   - 紀錄 podcast event
   - 紀錄 phone service
 - 現在需要持續擴充program progress log 的行為，但繼續擴充增加Porter Runner 的複雜性
故做refactor , 簡單將各部分類別化，並統一介面(execute funciton)