### PR TITLE
fix: change CarrierType from number to string

### DIFF
--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -373,7 +373,7 @@ export class InvoiceService {
     } else if (options.phoneBarCode) {
       invoiceAttrs = {
         Category: 'B2C',
-        CarrierType: 0,
+        CarrierType: '0',
         CarrierNum: options.phoneBarCode,
         PrintFlag: 'N',
       };
@@ -387,7 +387,7 @@ export class InvoiceService {
     } else if (options.citizenCode) {
       invoiceAttrs = {
         Category: 'B2C',
-        CarrierType: 1,
+        CarrierType: '1',
         CarrierNum: options.citizenCode,
         PrintFlag: 'N',
       };
@@ -395,7 +395,7 @@ export class InvoiceService {
       invoiceAttrs = {
         Category: 'B2C',
         PrintFlag: 'N',
-        CarrierType: 2,
+        CarrierType: '2',
         KioskPrintFlag: '1',
       };
     } else if (options.email) {


### PR DESCRIPTION
修正開立發票時 CarrierType 的資料型態錯誤，原本為數字，現改為字串。

- 將 CarrierType 由 number 調整為 string
- Trello 卡片：https://trello.com/c/esyWT9wD