### PR TITLE
fix: resolve missing CarrierNum field for CarrierType 2

### DIFF
--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -397,6 +397,7 @@ export class InvoiceService {
         PrintFlag: 'N',
         CarrierType: '2',
         KioskPrintFlag: '1',
+        CarrierNum: `${options.appId}-${options.email}`,
       };
     } else if (options.email) {
       invoiceAttrs = {


### PR DESCRIPTION
修正當 CarrierType = 2 時未夾帶 CarrierNum 欄位的問題，導致開立發票資料不完整。

- 原本後端未針對 CarrierType = 2 進行 CarrierNum 欄位補值，造成發票平台拒收或錯誤。
- Trello 卡牌：https://trello.com/c/esyWT9wD