### PR TITLE
fix: member created_at

### DIFF
--- a/src/member/entity/member.entity.ts
+++ b/src/member/entity/member.entity.ts
@@ -106,7 +106,7 @@ export class Member {
   @Column('timestamp with time zone', {
     name: 'created_at',
     nullable: true,
-    default: () => 'now()',
+    default: () => 'clock_timestamp()',
   })
   createdAt: Date | null;
 

--- a/src/member/member.dto.ts
+++ b/src/member/member.dto.ts
@@ -6,7 +6,6 @@ import {
   IsEmail,
   IsEnum,
   IsNumber,
-  IsObject,
   IsOptional,
   IsString,
   ValidateNested,
@@ -15,7 +14,6 @@ import { DeleteResult } from 'typeorm';
 import { Cursor } from 'typeorm-cursor-pagination';
 
 import { MemberRole } from './member.type';
-import { isArray } from 'lodash';
 
 class FileInfo {
   @IsString()


### PR DESCRIPTION
 - Use clock_timestamp() instead of now() to prevent duplicate created_at timestamps in the same transaction