### PR TITLE
Feature/add audit and table log

### DIFF
--- a/src/auth/device/device.service.ts
+++ b/src/auth/device/device.service.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 import { EntityManager } from 'typeorm';
 import UAParser from 'ua-parser-js';
 import { AppCache } from '~/app/app.type';
+import { Member } from '~/member/entity/member.entity';
 import { MemberDevice } from '~/member/entity/member_device.entity';
 import { MemberInfrastructure } from '~/member/member.infra';
 import { DeviceInfrastructure } from './device.infra';
@@ -157,6 +158,13 @@ export default class DeviceService {
     const devicesToBeLoggedOut = loginedDevices.slice(0, loginedDevices.length - loginLimit + 1);
     const devicesToBeLoggedOutIds = devicesToBeLoggedOut.map(v => v.id);
     await this.deviceInfra.logoutMemberDevices(devicesToBeLoggedOutIds, this.entityManager);
+
+    await this.memberInfra.insertMemberAuditLog(
+      [{ id: memberId } as Member],
+      JSON.stringify({ device_ids: devicesToBeLoggedOutIds, logout_type: 'forced' }),
+      'logout',
+      this.entityManager,
+    );
   }
 
   async expireFingerPrintId(fingerprintId: string): Promise<void> {
@@ -165,6 +173,13 @@ export default class DeviceService {
       const device = await memberDeviceRepo.findOneBy({ fingerprintId });
       device.isLogin = false;
       await manager.save(device);
+
+      await this.memberInfra.insertMemberAuditLog(
+        [{ id: device.memberId } as Member],
+        JSON.stringify({ fingerprint_id: fingerprintId, logout_type: 'expired' }),
+        'logout',
+        manager,
+      );
     };
     return cb(this.entityManager);
   }

--- a/src/member/entity/member_audit_log.entity.ts
+++ b/src/member/entity/member_audit_log.entity.ts
@@ -11,7 +11,7 @@ export class MemberAuditLog {
   memberId: string;
 
   @Column({ type: 'text' })
-  action: 'upload' | 'download' | 'delete';
+  action: 'upload' | 'download' | 'delete' | 'login' | 'logout';
 
   @Column({ type: 'text' })
   target: string;

--- a/src/member/member.infra.ts
+++ b/src/member/member.infra.ts
@@ -441,13 +441,27 @@ export class MemberInfrastructure {
     found.type = type;
     found.options = options;
 
-    return memberDeviceRepo.save(found);
+    const savedDevice = await memberDeviceRepo.save(found);
+
+    await this.insertMemberAuditLog(
+      [{ id: memberId } as Member],
+      JSON.stringify({
+        ip_address: ipAddress,
+        browser,
+        os_name: osName,
+        fingerprint_id: fingerPrintId,
+      }),
+      'login',
+      manager,
+    );
+
+    return savedDevice;
   }
 
   async insertMemberAuditLog(
     invokers: Array<Member>,
     target: string,
-    action: 'upload' | 'download',
+    action: 'upload' | 'download' | 'login' | 'logout',
     manager: EntityManager,
   ) {
     const memberAuditLogRepo = manager.getRepository(MemberAuditLog);

--- a/src/table_log/table_log.entity.ts
+++ b/src/table_log/table_log.entity.ts
@@ -5,6 +5,9 @@ export class TableLog {
   @PrimaryGeneratedColumn('uuid')
   id: ObjectId;
 
+  @Column({ type: 'text', name: 'member_id' })
+  memberId: string;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
@@ -14,9 +17,9 @@ export class TableLog {
   })
   tableName: string;
 
-  @Column({ type: 'json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   new: any | null;
 
-  @Column({ type: 'json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   old: any | null;
 }

--- a/src/table_log/table_log.service.ts
+++ b/src/table_log/table_log.service.ts
@@ -6,6 +6,7 @@ import { PgTrigger, TableOperation } from './table_log.type';
 import CheckTableTrigger from './sql/check_table_trigger';
 import CreateOrReplaceFunctionTableLog from './sql/create_or_replace_func_table';
 import CreateOrReplaceTrigger from './sql/create_or_replace_trigger';
+import { TableLog } from './table_log.entity';
 
 @Injectable()
 export class TableLogService {
@@ -34,5 +35,23 @@ export class TableLogService {
   ): Promise<void> {
     const manager = entityManager || this.entityManager;
     await manager.query(CreateOrReplaceTrigger(tableName, operation));
+  }
+
+  public async insert(
+    memberId: string,
+    tableName: string,
+    data: { old?: any; new?: any },
+    entityManager?: EntityManager,
+  ): Promise<TableLog> {
+    const manager = entityManager || this.entityManager;
+    const tableLogRepo = manager.getRepository(TableLog);
+
+    const log = new TableLog();
+    log.memberId = memberId;
+    log.tableName = tableName;
+    log.old = data.old || null;
+    log.new = data.new || null;
+
+    return tableLogRepo.save(log);
   }
 }

--- a/src/tasker/exporter.tasker.ts
+++ b/src/tasker/exporter.tasker.ts
@@ -24,6 +24,7 @@ import { ProductInfrastructure } from '~/product/product.infra';
 import { EmailService } from '~/mailer/email/email.service';
 import { AppInfrastructure } from '~/app/app.infra';
 import { VoucherInfrastructure } from '~/voucher/voucher.infra';
+import { TableLogService } from '~/table_log/table_log.service';
 
 dayjs.extend(timezone);
 dayjs.tz.setDefault('Asia/Taipei');
@@ -81,6 +82,7 @@ export class ExporterTasker extends Tasker {
         PaymentInfrastructure,
         SharingCodeInfrastructure,
         ProductInfrastructure,
+        TableLogService,
       ],
     };
   }
@@ -93,6 +95,7 @@ export class ExporterTasker extends Tasker {
     private readonly orderService: OrderService,
     private readonly memberInfra: MemberInfrastructure,
     private readonly appInfra: AppInfrastructure,
+    private readonly tableLogService: TableLogService,
     // @InjectQueue(MailerTasker.name) private readonly mailerQueue: Queue,
     @InjectQueue('mailer') private readonly mailerQueue: Queue,
     @InjectEntityManager() private readonly entityManager: EntityManager,
@@ -134,6 +137,19 @@ export class ExporterTasker extends Tasker {
       const signedDownloadUrl = await this.storageService.getSignedUrlForDownloadStorage(fileKey, 7 * 24 * 60 * 60);
 
       await this.memberInfra.insertMemberAuditLog(invokers, signedDownloadUrl, 'download', this.entityManager);
+
+      await this.tableLogService.insert(
+        invokerMemberId,
+        `${category}_export`,
+        {
+          new: {
+            file_key: fileKey,
+            category,
+            download_url: signedDownloadUrl,
+          },
+        },
+        this.entityManager,
+      );
 
       let subject;
       switch (job.data.category) {


### PR DESCRIPTION
## Summary                                                                                   
   
  - 新增登入/登出操作的 audit log 記錄                                                         
  - 新增匯出操作的 table_log 記錄                                                              
   
  ## Changes                                                                                   
                  
  ### 1. 登入/登出 Audit Log (`member_audit_log`)

  - 在 `MemberInfrastructure.upsertMemberDevice` 中記錄登入事件
  - 在 `DeviceService.logoutExcessDevices` 中記錄強制登出事件
  - 在 `DeviceService.expireFingerPrintId` 中記錄裝置過期登出事件

  ### 2. 匯出 Table Log (`table_log`)

  - 新增 `TableLogService.insert()` 方法，支援手動寫入 table_log
  - 在 `ExporterTasker` 整合 TableLogService
  - 匯出完成時記錄到 table_log


  ## Test Plan

  - [ ] 測試登入後 `member_audit_log` 有 action='login' 的記錄
  - [ ] 測試裝置被強制登出後有 action='logout', logout_type='forced' 的記錄
  - [ ] 測試匯出後 `table_log` 有對應的 `*_export` 記錄
  
  
<img width="949" height="525" alt="截圖 2026-02-23 下午3 00 00" src="https://github.com/user-attachments/assets/93ba75f6-1cf6-44d2-87a0-24a132cae3be" />
