### PR TITLE
fix(storage): multipart complete 重試遇到 NoSuchUpload 不該回 500

### DIFF
--- a/src/utility/storage/storage.service.spec.ts
+++ b/src/utility/storage/storage.service.spec.ts
@@ -1,0 +1,77 @@
+import { ConfigService } from '@nestjs/config';
+import { S3Client, CompleteMultipartUploadCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { StorageService } from './storage.service';
+
+const REGION = 'us-east-1';
+const BUCKET = 'test-bucket';
+
+function makeService(): StorageService {
+  const configService = {
+    getOrThrow: (key: string) => (key === 'AWS_S3_REGION_STORAGE' ? REGION : BUCKET),
+  } as unknown as ConfigService;
+  return new StorageService(configService);
+}
+
+function noSuchUploadError(): Error {
+  const err = new Error(
+    'The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.',
+  );
+  err.name = 'NoSuchUpload';
+  return err;
+}
+
+function notFoundError(): Error {
+  const err = new Error('Not Found');
+  err.name = 'NotFound';
+  return err;
+}
+
+describe('StorageService.completeMultipartUpload (idempotency)', () => {
+  let service: StorageService;
+
+  beforeEach(() => {
+    service = makeService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('treats an already-completed upload as success instead of throwing', async () => {
+    // S3 deletes the UploadId after a successful complete, so a retried
+    // complete throws NoSuchUpload even though the object is already there.
+    jest.spyOn(S3Client.prototype, 'send').mockImplementation((command: any) => {
+      if (command instanceof CompleteMultipartUploadCommand) {
+        return Promise.reject(noSuchUploadError());
+      }
+      if (command instanceof HeadObjectCommand) {
+        return Promise.resolve({ ContentLength: 123 }); // object exists
+      }
+      return Promise.reject(new Error('unexpected command'));
+    });
+
+    const result = await service.completeMultipartUpload('vod/app/key', 'dead-upload-id', {
+      Parts: [{ PartNumber: 1, ETag: 'abc' }],
+    });
+
+    expect(result.Location).toContain('vod/app/key');
+  });
+
+  it('rethrows NoSuchUpload when the object does not actually exist', async () => {
+    jest.spyOn(S3Client.prototype, 'send').mockImplementation((command: any) => {
+      if (command instanceof CompleteMultipartUploadCommand) {
+        return Promise.reject(noSuchUploadError());
+      }
+      if (command instanceof HeadObjectCommand) {
+        return Promise.reject(notFoundError()); // object missing
+      }
+      return Promise.reject(new Error('unexpected command'));
+    });
+
+    await expect(
+      service.completeMultipartUpload('vod/app/key', 'dead-upload-id', {
+        Parts: [{ PartNumber: 1, ETag: 'abc' }],
+      }),
+    ).rejects.toThrow('The specified upload does not exist');
+  });
+});

--- a/src/utility/storage/storage.service.ts
+++ b/src/utility/storage/storage.service.ts
@@ -14,6 +14,7 @@ import {
   UploadPartCommand,
   CompleteMultipartUploadCommand,
   CompletedMultipartUpload,
+  HeadObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Injectable } from '@nestjs/common';
@@ -94,7 +95,31 @@ export class StorageService {
       UploadId,
       MultipartUpload,
     });
-    return this.s3(this.awsS3RegionStorage).send(command);
+    try {
+      return await this.s3(this.awsS3RegionStorage).send(command);
+    } catch (error) {
+      // S3 deletes the UploadId once a complete succeeds, so a retried request
+      // (e.g. the client never received the first response) throws NoSuchUpload
+      // even though the object is already assembled. Treat that as success
+      // instead of surfacing a misleading 500 that the caller retries forever.
+      if ((error as { name?: string })?.name === 'NoSuchUpload' && (await this.objectExistsInStorage(Key))) {
+        return {
+          Bucket: this.awsS3BucketStorage,
+          Key,
+          Location: `https://${this.awsS3BucketStorage}.s3.${this.awsS3RegionStorage}.amazonaws.com/${Key}`,
+        };
+      }
+      throw error;
+    }
+  }
+
+  private async objectExistsInStorage(Key: string): Promise<boolean> {
+    try {
+      await this.s3(this.awsS3RegionStorage).send(new HeadObjectCommand({ Bucket: this.awsS3BucketStorage, Key }));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   getSignedUrlForUploadPartStorage(


### PR DESCRIPTION
## 問題

正式站 `nschool.tw` 多支影片卡在「上架中」,操作者看到的錯誤是:

```
complete 500: {"statusCode":500,"message":"Internal server error"}
```

近 5 天 `/api/v2/storage/multipart/complete`:64 成功、11 個 500,500 全來自 nschool,responseTime 都只有 ~750ms(非逾時)。

## 根因(由正式站 CloudWatch log 確認)

```
NoSuchUpload: The specified upload does not exist.
The upload ID may be invalid, or the upload may have been aborted or completed.
    at de_CompleteMultipartUploadCommandError (@aws-sdk/client-s3 …)
```

S3 在 `CompleteMultipartUpload` 成功的當下就會把該 `UploadId` 作廢。若客戶端沒收到第一次的成功回應(逾時/斷線),它會拿**同一個 UploadId 重試**,於是 S3 回 `NoSuchUpload`。原本的 handler 沒有 try/catch,這個例外直接變成裸 `500 Internal server error`,客戶端便無止盡重試——但其實物件早就完整存進 bucket 了(已用 `s3api head-object` 核對,大小與來源完全一致)。

## 修法

`StorageService.completeMultipartUpload`:捕到 `NoSuchUpload` 時,先 `HeadObject` 確認物件是否已存在;
- 已存在 → 視為成功回傳 location(冪等),讓重試收斂。
- 真的不存在 → 照常 rethrow。

改動只在 storage service 一處,風險低。後續 cherry-pick 到 `release` 部署正式站後,操作者重按一次上架,卡住的列即會通過,**影片不需重傳**。

## 測試

新增 `storage.service.spec.ts`,以 red→green 驗證:
- already-completed(物件存在)→ 不丟例外、回傳含 Location ✓
- 物件真的不存在 → 仍 rethrow NoSuchUpload ✓

`yarn jest src/media src/utility/storage` 全綠(16 tests),lint/typecheck 無新增錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)